### PR TITLE
test-build task will now only delete images with the 'confluentinc' 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ docker-env:
 	$(shell docker-machine env gce)
 
 test-build: venv
-	docker images -q | grep ^confluentinc | xargs  docker rmi -f
+	docker images | grep ^confluentinc | xargs  docker rmi -f
 	IMAGE_DIR=$(pwd) venv/bin/py.test tests/test_build.py -v
-	docker images -q | grep ^confluentinc | xargs  docker rmi -f
+	docker images | grep ^confluentinc | xargs  docker rmi -f
 
 test-zookeeper: venv build-debian
 	docker ps -a -q | xargs  docker rm -f


### PR DESCRIPTION
When running `test-build` on my own machine before this fix all images were being deleted (without warning), I figure it's probably better to only delete the relevant images.
