### PR TITLE
How to contrib changes

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -116,36 +116,3 @@ GitHub Workflow
   .. sourcecode:: bash
 
     $ git push origin --force feature-xxx
-
-FAQ
-~~~
-
-Help! I merged changes from upstream and cannot figure out how to resolve conflicts when rebasing!
-
-Never fear! If you occasionally merged upstream/master, here is another way to squash your changes into a single commit:
-
-1. First, rename your existing branch to something else, e.g. `feature-xxx-unclean`
-
-  .. sourcecode:: bash
-    
-    $ git branch -m feature-xxx-unclean
-
-
-2. Checkout a new branch with the original name `feature-xxx` from upstream. This branch will supercede our old one.
-
-  .. sourcecode:: bash
-
-  $ git checkout -b feature-xxx upstream/master
-
-3. Then merge your changes in your original feature branch `feature-xxx-unclean` and create a single commit.
-
-  .. sourcecode:: bash
-
-    $ git merge --squash feature-xxx-unclean
-    $ git commit
-
-4. You can now submit this new branch and create or replace your existing pull request.
-
-  .. sourcecode:: bash
-    
-    $ git push origin [--force] feature-xxx:feature-xxx


### PR DESCRIPTION
@arrawatia and @samjhecht I'm suggesting here to remove the FAQ from how to contrib.  We should expect people to know how to use git themselves or go to git directly for questions around that.  The rest LGTM.  Can you confirm it's ok to remove the FAQ?
