### PR TITLE
First version of new example: single-node complete CP deployment

### DIFF
--- a/debian/kafka-rest/include/etc/confluent/docker/apply-mesos-overrides
+++ b/debian/kafka-rest/include/etc/confluent/docker/apply-mesos-overrides
@@ -14,24 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o nounset \
-    -o errexit \
-    -o verbose \
-    -o xtrace
+# Mesos DC/OS docker deployments will have HOST and PORT0 
+# set for the proxying of the service.
+# 
+# Use those values provide things we know we'll need.
 
-. /etc/confluent/docker/apply-mesos-overrides
+[ -n "${HOST:-}" ] && [ -z "${KAFKA_REST_HOST:-}" ] && \
+	export KAFKA_REST_HOST=$HOST || true # we don't want the setup to fail if not on Mesos
 
-echo "===> ENV Variables ..."
-env | sort
-
-echo "===> User"
-id
-
-echo "===> Configuring ..."
-/etc/confluent/docker/configure
-
-echo "===> Running preflight checks ... "
-/etc/confluent/docker/ensure
-
-echo "===> Launching ... "
-exec /etc/confluent/docker/launch

--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -10,22 +10,22 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
-  kafka:
+  broker:
     image: confluentinc/cp-kafka:3.0.1
-    hostname: kafka
+    hostname: broker
     ports:
       - '9092'
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker:9092'
 
   schema_registry:
     image: confluentinc/cp-schema-registry:3.0.1
     hostname: schema_registry
     depends_on:
       - zookeeper
-      - kafka
+      - broker
     ports:
       - '8081'
     environment:
@@ -37,12 +37,12 @@ services:
     hostname: connect
     depends_on:
       - zookeeper
-      - kafka
+      - broker
       - schema_registry
     ports:
       - "8083:8083"
     environment:
-      CONNECT_BOOTSTRAP_SERVERS: 'kafka:9092'
+      CONNECT_BOOTSTRAP_SERVERS: 'broker:9092'
       CONNECT_REST_ADVERTISED_HOST_NAME: connect
       CONNECT_REST_PORT: 8083
       CONNECT_GROUP_ID: compose-connect-group
@@ -57,18 +57,18 @@ services:
       CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       CONNECT_ZOOKEEPER_CONNECT: 'zookeeper:2181'
 
-  control_center:
+  control-center:
     image: confluentinc/cp-control-center:3.0.1
     hostname: control-center
     depends_on:
       - zookeeper
-      - kafka
+      - broker
       - schema_registry
       - connect
     ports:
       - "9021:9021"
     environment:
-      CONTROL_CENTER_BOOTSTRAP_SERVERS: 'kafka:9092'
+      CONTROL_CENTER_BOOTSTRAP_SERVERS: 'broker:9092'
       CONTROL_CENTER_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       CONTROL_CENTER_CONNECT_CLUSTER: 'connect:8083'
       CONTROL_CENTER_REPLICATION_FACTOR: 1

--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     ports:
       - '8081'
     environment:
-      HOST: schema_registry
+      SCHEMA_REGISTRY_HOST_NAME: schema_registry
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
@@ -42,8 +42,8 @@ services:
     ports:
       - "8083:8083"
     environment:
-      HOST: connect
       CONNECT_BOOTSTRAP_SERVERS: 'kafka:9092'
+      CONNECT_REST_ADVERTISED_HOST_NAME: connect
       CONNECT_REST_PORT: 8083
       CONNECT_GROUP_ID: compose-connect-group
       CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs

--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -1,0 +1,78 @@
+---
+version: '2'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:3.0.1
+    hostname: zookeeper
+    ports:
+      - '2181'
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:3.0.1
+    hostname: kafka
+    ports:
+      - '9092'
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
+
+  schema_registry:
+    image: confluentinc/cp-schema-registry:3.0.1
+    hostname: schema_registry
+    depends_on:
+      - zookeeper
+      - kafka
+    ports:
+      - '8081'
+    environment:
+      HOST: schema_registry
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
+
+  connect:
+    image: confluentinc/cp-kafka-connect:3.0.1
+    hostname: connect
+    depends_on:
+      - zookeeper
+      - kafka
+      - schema_registry
+    ports:
+      - "8083:8083"
+    environment:
+      HOST: connect
+      CONNECT_BOOTSTRAP_SERVERS: 'kafka:9092'
+      CONNECT_REST_PORT: 8083
+      CONNECT_GROUP_ID: compose-connect-group
+      CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs
+      CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
+      CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
+      CONNECT_KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
+      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: 'http://schema_registry:8081'
+      CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://schema_registry:8081'
+      CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+
+  control_center:
+    image: confluentinc/cp-control-center:3.0.1
+    hostname: control-center
+    depends_on:
+      - zookeeper
+      - kafka
+      - schema_registry
+      - connect
+    ports:
+      - "9021:9021"
+    environment:
+      CONTROL_CENTER_BOOTSTRAP_SERVERS: 'kafka:9092'
+      CONTROL_CENTER_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      CONTROL_CENTER_CONNECT_CLUSTER: 'connect:8083'
+      CONTROL_CENTER_REPLICATION_FACTOR: 1
+      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
+      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
+      PORT: 9021
+


### PR DESCRIPTION
Now that docker-for-mac is more stable, this example allows a standalone deployment of 
ALL the platform components (including a Control Center that will enable Connector config).

Happy to add details to the doc pages if necessary.
