### PR TITLE
Fix double log4j logging

### DIFF
--- a/debian/kafka/include/etc/confluent/docker/log4j.properties.template
+++ b/debian/kafka/include/etc/confluent/docker/log4j.properties.template
@@ -22,5 +22,5 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 {% endif %}
 
 {% for logger,loglevel in loggers.iteritems() %}
-log4j.logger.{{logger}}={{loglevel}}, stdout
+log4j.logger.{{logger}}={{loglevel}}
 {% endfor %}


### PR DESCRIPTION
The root logger (line 2) already has "stdout", and thus it's inherited automatically by sub-loggers.  By specifying them in sub-loggers it results in twice the log messages.