### PR TITLE
Feature/rest proxy cors headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_VERSION := 2
+DOCKER_VERSION := 3
 CP_VERSION := 3.0.1
 VERSION := ${CP_VERSION}-${DOCKER_VERSION}
 COMPONENTS := base zookeeper kafka kafka-rest schema-registry kafka-connect control-center kafkacat

--- a/debian/kafka-rest/include/etc/confluent/docker/kafka-rest.properties.template
+++ b/debian/kafka-rest/include/etc/confluent/docker/kafka-rest.properties.template
@@ -16,7 +16,9 @@ zookeeper.connect={{env['KAFKA_REST_ZOOKEEPER_CONNECT']}}
 	'KAFKA_REST_CONSUMER_THREADS': 'consumer.threads',
 	'KAFKA_REST_CONSUMER_INSTANCE_TIMEOUT_MS': 'consumer.instance.timeout.ms',
 	'KAFKA_REST_SIMPLE_CONSUMER_MAX_POOL_SIZE': 'simpleconsumer.pool.size.max',
-	'KAFKA_REST_SIMPLE_CONSUMER_POOL_TIMEOUT_MS': 'simpleconsumer.pool.timeout.ms'
+	'KAFKA_REST_SIMPLE_CONSUMER_POOL_TIMEOUT_MS': 'simpleconsumer.pool.timeout.ms',
+	'KAFKA_REST_ACCESS_CONTROL_ALLOW_ORIGIN': 'access.control.allow.origin',
+	'KAFKA_REST_ACCESS_CONTROL_ALLOW_METHODS': 'access.control.allow.methods'
  } -%}
 
  {% for k, property in other_props.iteritems() -%}


### PR DESCRIPTION
Copy the CORS related headers for the REST Proxy into the generated config file so that they get picked up by the CrossOriginFilter.