### PR TITLE
Switch debian url to production

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -36,7 +36,7 @@ ENV CONFLUENT_MINOR_VERSION="1"
 ENV CONFLUENT_PATCH_VERSION="0"
 ENV CONFLUENT_VERSION="$CONFLUENT_MAJOR_VERSION.$CONFLUENT_MINOR_VERSION.$CONFLUENT_PATCH_VERSION"
 ENV CONFLUENT_DEB_VERSION="1"
-ENV CONFLUENT_DEB_REPO="https://s3-us-west-2.amazonaws.com/staging-confluent-packages-3.1.0"
+ENV CONFLUENT_DEB_REPO="http://packages.confluent.io"
 
 ENV KAFKA_VERSION="0.10.1.0"
 
@@ -56,8 +56,6 @@ RUN echo "===> Updating debian ....." \
                 wget \
                 netcat \
                 python=${PYTHON_VERSION} \
-    # REMOVE LATER : Only for nightlies / staging
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https  \
     && echo "===> Installing python packages ..."  \
     && curl -fSL 'https://bootstrap.pypa.io/get-pip.py' | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \

--- a/tests/test_enterprise_kafka.py
+++ b/tests/test_enterprise_kafka.py
@@ -106,7 +106,7 @@ class ClusterHostNetworkTest(unittest.TestCase):
             command=ADB_EXECUTE.format(brokers="localhost:19092", throttle_bps=100000000, remove_broker=removed_broker),
             host_config={'NetworkMode': 'host'})
 
-        assert "Rebalance started, its status can be checked via the status command." in execute_logs
+        assert "Computing the rebalance plan (this may take a while)" in execute_logs
 
         rebalance_status = self.cluster.run_command_on_service("kafka-1", ADB_STATUS)
 
@@ -115,7 +115,7 @@ class ClusterHostNetworkTest(unittest.TestCase):
             rebalance_complete = self.cluster.run_command_on_service("kafka-1", ADB_FINISH)
             if "The rebalance has completed and throttling has been disabled" in rebalance_complete:
                 break
-            sleep(1)
+            time.sleep(1)
 
         assert "The rebalance has completed and throttling has been disabled" in rebalance_complete
 

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -347,7 +347,7 @@ class StandaloneNetworkingTest(unittest.TestCase):
             image="confluentinc/cp-jmxterm",
             command=JMX_CHECK.format(jmx_hostname="localhost", jmx_port="39999"),
             host_config={'NetworkMode': 'host'})
-        self.assertTrue("Version = 0.10.1.0;" in logs)
+        self.assertTrue("Version = 0.10.1.0-cp1;" in logs)
 
     def test_jmx_bridged_network(self):
 
@@ -356,7 +356,7 @@ class StandaloneNetworkingTest(unittest.TestCase):
             image="confluentinc/cp-jmxterm",
             command=JMX_CHECK.format(jmx_hostname="kafka-bridged-jmx", jmx_port="9999"),
             host_config={'NetworkMode': 'standalone-network-test_zk'})
-        self.assertTrue("Version = 0.10.1.0;" in logs)
+        self.assertTrue("Version = 0.10.1.0-cp1;" in logs)
 
 
 class ClusterBridgedNetworkTest(unittest.TestCase):

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -9,7 +9,7 @@ FIXTURES_DIR = os.path.join(CURRENT_DIR, "fixtures", "debian", "zookeeper")
 MODE_COMMAND = "bash -c 'dub wait localhost {port} 30 && echo stat | nc localhost {port} | grep Mode'"
 HEALTH_CHECK = "bash -c 'cub zk-ready {host}:{port} 30 && echo PASS || echo FAIL'"
 JMX_CHECK = """bash -c "\
-    echo 'get -b org.apache.ZooKeeperService:name0=StandaloneServer_port-1 Version' |
+    echo 'get -b org.apache.ZooKeeperService:name0=StandaloneServer_port{client_port} Version' |
         java -jar jmxterm-1.0-alpha-4-uber.jar -l {jmx_hostname}:{jmx_port} -n -v silent "
 """
 KADMIN_KEYTAB_CREATE = """bash -c \
@@ -200,18 +200,18 @@ class StandaloneNetworkingTest(unittest.TestCase):
         # Test from outside the container
         logs = utils.run_docker_command(
             image="confluentinc/cp-jmxterm",
-            command=JMX_CHECK.format(jmx_hostname="localhost", jmx_port="39999"),
+            command=JMX_CHECK.format(client_port=52181, jmx_hostname="localhost", jmx_port="39999"),
             host_config={'NetworkMode': 'host'})
-        self.assertTrue("Version = 3.4.6-1569965, built on 02/20/2014 09:09 GMT;" in logs)
+        self.assertTrue("Version = 3.4.8--1, built on 02/06/2016 03:18 GMT;" in logs)
 
     def test_jmx_bridged_network(self):
 
         # Test from outside the container
         logs = utils.run_docker_command(
             image="confluentinc/cp-jmxterm",
-            command=JMX_CHECK.format(jmx_hostname="bridge-network-jmx", jmx_port="9999"),
+            command=JMX_CHECK.format(client_port=2181, jmx_hostname="bridge-network-jmx", jmx_port="9999"),
             host_config={'NetworkMode': 'standalone-network-test_zk'})
-        self.assertTrue("Version = 3.4.6-1569965, built on 02/20/2014 09:09 GMT;" in logs)
+        self.assertTrue("Version = 3.4.8--1, built on 02/06/2016 03:18 GMT;" in logs)
 
 
 class ClusterBridgeNetworkTest(unittest.TestCase):


### PR DESCRIPTION
@samjhecht @theduderog Can you please review this PR ?

Changes:
- Change the deb URL to http://packages.confluent.io
- Fix all failing tests

We can build and upload docker images once we merge this PR.