### PR TITLE
JMX Warning message refers to wrong env var

### DIFF
--- a/debian/zookeeper/include/etc/confluent/docker/configure
+++ b/debian/zookeeper/include/etc/confluent/docker/configure
@@ -41,7 +41,7 @@ if [[ -n "${KAFKA_JMX_OPTS-}" ]]
 then
   if [[ ! $KAFKA_JMX_OPTS == *"com.sun.management.jmxremote.rmi.port"*  ]]
   then
-    echo "KAFKA_OPTS should contain 'com.sun.management.jmxremote.rmi.port' property. It is required for accessing the JMX metrics externally."
+    echo "KAFKA_JMX_OPTS should contain 'com.sun.management.jmxremote.rmi.port' property. It is required for accessing the JMX metrics externally."
   fi
 fi
 


### PR DESCRIPTION
The warning message refers to KAFKA_OPTS but as you can see from the condition, the env var KAFKA_JMX_OPTS is what's pertinent.