### PR TITLE
Update docker-compose.yml

### DIFF
--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -32,7 +32,8 @@ services:
       - '8081'
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema_registry
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181
+      SCHEMA_REGISTRY_LISTENERS: "http://0.0.0.0:8081"
 
   connect:
     image: confluentinc/cp-kafka-connect

--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - '8081'
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema_registry
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
       SCHEMA_REGISTRY_LISTENERS: "http://0.0.0.0:8081"
 
   connect:


### PR DESCRIPTION
The schema registry docker image seems to be missing the schema_registry_listeners environment variable. When trying to spin this up a fatal error occurs.