### PR TITLE
kafka-rest: Fix for NullReferenceException in kafka-ready (SSL enabled)

### DIFF
--- a/debian/kafka-rest/include/etc/confluent/docker/ensure
+++ b/debian/kafka-rest/include/etc/confluent/docker/ensure
@@ -23,7 +23,15 @@ echo "===> Check if Zookeeper is healthy ..."
 cub zk-ready "$KAFKA_REST_ZOOKEEPER_CONNECT" "${KAFKA_REST_CUB_ZK_TIMEOUT:-40}"
 
 echo "===> Check if Kafka is healthy ..."
-cub kafka-ready \
-    "${KAFKA_REST_CUB_KAFKA_MIN_BROKERS:-1}" \
-    "${KAFKA_REST_CUB_KAFKA_TIMEOUT:-40}" \
-    -z "$KAFKA_REST_ZOOKEEPER_CONNECT"
+if [[ -n "${KAFKA_REST_SECURITY_PROTOCOL-}" ]] && [[ $KAFKA_REST_SECURITY_PROTOCOL="SSL" ]]
+then
+    cub kafka-ready 1 \
+        "${KAFKA_REST_CUB_KAFKA_TIMEOUT:-40}" \
+        -b "${KAFKA_REST_BOOTSTRAP_SERVERS}" \
+        --config /etc/"${COMPONENT}"/kafka-rest.properties
+else
+    cub kafka-ready \
+        "${KAFKA_REST_CUB_KAFKA_MIN_BROKERS:-1}" \
+        "${KAFKA_REST_CUB_KAFKA_TIMEOUT:-40}" \
+        -z "$KAFKA_REST_ZOOKEEPER_CONNECT"
+fi


### PR DESCRIPTION
This is a change similar to that for issue #176 but for Kafka Rest. Following a similar approach.

This allows me to get past the `kafka-ready` step and use an `http` or `https` listener with an SSL Kafka cluster.