### PR TITLE
Issue 180, 190 and docs improvements

### DIFF
--- a/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
+++ b/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
@@ -1,5 +1,5 @@
 
-clientPort={{ env['ZOOKEEPER_CLIENT_PORT'] }}
+clientPort={{ env['ZOOKEEPER_CLIENT_PORT'] | default('2181') }}
 dataDir=/var/lib/zookeeper/data
 dataLogDir=/var/lib/zookeeper/log
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -97,9 +97,12 @@ Setup
          --amazonec2-region us-west-2 \
          --amazonec2-instance-type m4.large \
          --amazonec2-root-size 100 \
-         --amazonec2-ami ami-16b1a077 \
          --amazonec2-tags Name,$INSTANCE_NAME \
          $USER-aws-confluent
+
+  .. note::
+
+    You can also specify the AMI by setting ``amazonec2-ami <ami_version>``.  However, if a specific AMI is not specified, the latest nightly build AMI will be used.
 
 3. Configure your terminal window to attach it to your new Docker Machine:
 

--- a/docs/security/security.rst
+++ b/docs/security/security.rst
@@ -12,7 +12,7 @@ Using security is optional - non-secured clusters are supported, as well as a mi
    "Zookeeper", "SASL"
    "Kafka", "SASL, SSL"
    "Confluent Control Center", "HTTPS"
-   "Schema Registry", "HTTPS",
+   "Schema Registry", "HTTPS"
    "REST Proxy", "HTTPS"
    "Kafka Connect", "None"
 

--- a/docs/security/security.rst
+++ b/docs/security/security.rst
@@ -12,13 +12,15 @@ Using security is optional - non-secured clusters are supported, as well as a mi
    "Zookeeper", "SASL"
    "Kafka", "SASL, SSL"
    "Confluent Control Center", "HTTPS"
-   "Schema Registry", "HTTPS"
+   "Schema Registry", "HTTPS",
    "REST Proxy", "HTTPS"
    "Kafka Connect", "None"
 
 For details on available security features in Confluent platform, please refer to the `Confluent Platform Security Overview Documentation <http://docs.confluent.io/3.1.1/kafka/security.html>`_.
 
-For a tutorial on using SSL in the Confluent Platform please refer to the documented tutorials on `SSL <http://docs.confluent.io/3.1.1/kafka/ssl.html>`_ and `SASL <http://docs.confluent.io/3.1.1/kafka/sasl.html>`_.
+For tutorials on enabling security for Docker deployments of the Confluent Platform, please refer to the following tutorials:
+  - `SSL <http://docs.confluent.io/current/cp-docker-images/docs/tutorials/clustered-deployment-ssl.html>`_
+  - `SASL <http://docs.confluent.io/current/cp-docker-images/docs/tutorials/clustered-deployment-sasl.html>`_.
 
 Docker Security
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
* Fix issue reported in #180 - make ZOOKEEPER_CLIENT_PORT default to 2181

* fix links to security tutorials per https://github.com/confluentinc/cp-docker-images/issues/190

* remove specific AMI from development docs `docker-machine create` example.  The one we included was no longer available and it's not necessary to specify it anyway.