### PR TITLE
Create example of Confluent stack with overlay networks

### DIFF
--- a/examples/cp-kafka-overlay/README.md
+++ b/examples/cp-kafka-overlay/README.md
@@ -1,0 +1,37 @@
+# RADAR-CNS with multi-node cluster using Docker Swarm 
+
+
+# If you require attachable networks for testing, you'll need to create them as external e.g.
+```sh
+docker network create --attachable --driver overlay zookeeper
+docker network create --attachable --driver overlay kafka
+docker network create --attachable --driver overlay api
+```
+
+
+# Run the full setup with (NB! --compose-file only works with Docker v1.13.x)
+```sh
+docker deploy --compose-file docker-compose.yml kafka-overlay
+```
+
+
+
+#Test
+```sh
+docker run --net=zookeeper --rm confluentinc/cp-zookeeper:3.1.1 bash -c "echo stat | nc zookeeper-1 2181 | grep Mode"
+```
+> Mode: standalone
+
+```sh
+docker run --net=kafka --rm confluentinc/cp-kafka:3.1.1 kafka-topics --create --topic foo --partitions 1 --replication-factor 1 --if-not-exists --zookeeper zookeeper-1:2181
+```
+> Created topic "foo".
+
+
+```sh
+docker run --net=kafka --rm confluentinc/cp-kafka:3.1.1 kafka-topics --describe --topic foo --zookeeper zookeeper-1:2181
+```
+> Topic:foo   PartitionCount:1    ReplicationFactor:1 Configs:
+>    Topic: foo  Partition: 0    Leader: 3   Replicas: 3 Isr: 3
+
+

--- a/examples/cp-kafka-overlay/docker-compose.yml
+++ b/examples/cp-kafka-overlay/docker-compose.yml
@@ -1,0 +1,120 @@
+---
+version: '3'
+
+#networks:
+#  zookeeper:
+#    driver: overlay
+#  kafka:
+#    driver: overlay
+#  api:
+#    driver: overlay
+
+networks:
+  zookeeper:
+    driver: overlay
+    external: true
+  kafka:
+    driver: overlay
+    external: true
+  api:
+    driver: overlay
+    external: true
+
+services:
+
+  #---------------------------------------------------------------------------#
+  # Zookeeper Cluster                                                         #
+  #---------------------------------------------------------------------------#
+  zookeeper-1:
+    image: confluentinc/cp-zookeeper:3.1.1
+    networks:
+      - zookeeper
+      - kafka #for testing only
+    environment:
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_INIT_LIMIT: 5
+      ZOOKEEPER_SYNC_LIMIT: 2
+      ZOOKEEPER_SERVERS: zookeeper-1:2888:3888
+
+  #---------------------------------------------------------------------------#
+  # Kafka Cluster                                                             #
+  #---------------------------------------------------------------------------#
+  kafka-1:
+    image: confluentinc/cp-kafka:3.1.1
+    networks:
+      - kafka
+      - zookeeper
+    depends_on:
+      - zookeeper-1
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:9092
+
+  kafka-2:
+    image: confluentinc/cp-kafka:3.1.1
+    networks:
+      - kafka
+      - zookeeper
+    depends_on:
+      - kafka-1
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:9092
+
+  kafka-3:
+    image: confluentinc/cp-kafka:3.1.1
+    networks:
+      - kafka
+      - zookeeper
+    depends_on:
+      - kafka-2
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:9092
+
+  #---------------------------------------------------------------------------#
+  # Schema Registry                                                           #
+  #---------------------------------------------------------------------------#
+  schema-registry-1:
+    image: confluentinc/cp-schema-registry:3.1.1
+    networks:
+      - kafka
+      - zookeeper
+    depends_on:
+      - kafka-1
+      - kafka-2
+      - kafka-3
+    restart: always
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper-1:2181
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry-1
+      SCHEMA_REGISTRY_LISTENERS: http://schema-registry-1:8081
+
+  #---------------------------------------------------------------------------#
+  # REST proxy                                                                #
+  #---------------------------------------------------------------------------#
+  rest-proxy-1:
+    image: confluentinc/cp-kafka-rest:3.1.1
+    networks:
+      - kafka
+      - zookeeper
+    depends_on:
+      - kafka-1
+      - kafka-2
+      - kafka-3
+      - schema-registry-1
+    ports:
+      - "8082:8082"
+    environment:
+      KAFKA_REST_ZOOKEEPER_CONNECT: zookeeper-1:2181
+      KAFKA_REST_LISTENERS: http://rest-proxy-1:8082
+      KAFKA_REST_SCHEMA_REGISTRY_URL: http://schema-registry-1:8081
+      KAFKA_REST_HOST_NAME: rest-proxy-1
+


### PR DESCRIPTION
This adds an example deployment of Confluent components on Swarm, using overlay networks. Might be a starter to address confluentinc/cp-docker-images#49

**Caveats** 
- docker 1.13.x and above (for the `docker deploy --compose-file` option)
- can't create attachable networks in the docker-compose.yml file
- no idea about performance (but probably not great)
- there seem to be issues with multiple zookeeper instances RADAR-CNS/RADAR-Docker#7