### PR TITLE
Connect: Removed stdout from custom loggers so it doesn't output duplicate log

### DIFF
--- a/debian/kafka-connect-base/include/etc/confluent/docker/log4j.properties.template
+++ b/debian/kafka-connect-base/include/etc/confluent/docker/log4j.properties.template
@@ -8,6 +8,6 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 {% if env['CONNECT_LOG4J_LOGGERS'] %}
 {% set loggers = parse_log4j_loggers(env['CONNECT_LOG4J_LOGGERS']) %}
 {% for logger,loglevel in loggers.iteritems() %}
-log4j.logger.{{logger}}={{loglevel}}, stdout
+log4j.logger.{{logger}}={{loglevel}}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
this mimic the behaviour at
https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template#L25