### PR TITLE
kafka-ready for Kafka Connect fails when using SSL (#194)

### DIFF
--- a/debian/kafka-connect-base/include/etc/confluent/docker/ensure
+++ b/debian/kafka-connect-base/include/etc/confluent/docker/ensure
@@ -21,7 +21,18 @@ set -o nounset \
 
 echo "===> Check if Kafka is healthy ..."
 
-cub kafka-ready \
-    "${CONNECT_CUB_KAFKA_MIN_BROKERS:-1}" \
-    "${CONNECT_CUB_KAFKA_TIMEOUT:-40}" \
-    -b "$CONNECT_BOOTSTRAP_SERVERS"
+if [[ -n "${CONNECT_SECURITY_PROTOCOL-}" ]] && [[ $CONNECT_SECURITY_PROTOCOL="SSL" ]]
+then
+
+    cub kafka-ready \
+        "${CONNECT_CUB_KAFKA_MIN_BROKERS:-1}" \
+        "${CONNECT_CUB_KAFKA_TIMEOUT:-40}" \
+        -b "$CONNECT_BOOTSTRAP_SERVERS" \
+        --config /etc/"${COMPONENT}"/kafka-connect.properties
+else
+
+    cub kafka-ready \
+        "${CONNECT_CUB_KAFKA_MIN_BROKERS:-1}" \
+        "${CONNECT_CUB_KAFKA_TIMEOUT:-40}" \
+        -b "$CONNECT_BOOTSTRAP_SERVERS"
+fi


### PR DESCRIPTION
This is to backport changes to support SSL on kafka-ready for Kafka Connect in 3.1.x. @samjhecht or @arrawatia please take a look and if it's ok please publish updated images including this commit. Thanks!