### PR TITLE
Fix SR SSL issue

### DIFF
--- a/debian/schema-registry/include/etc/confluent/docker/admin.properties.template
+++ b/debian/schema-registry/include/etc/confluent/docker/admin.properties.template
@@ -1,0 +1,4 @@
+{% set security_props = env_to_props('SCHEMA_REGISTRY_KAFKASTORE_', '') -%}
+{% for name, value in security_props.iteritems() -%}
+{{name}}={{value}}
+{% endfor -%}

--- a/debian/schema-registry/include/etc/confluent/docker/configure
+++ b/debian/schema-registry/include/etc/confluent/docker/configure
@@ -39,3 +39,4 @@ fi
 
 dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "/etc/${COMPONENT}/${COMPONENT}.properties"
 dub template "/etc/confluent/docker/log4j.properties.template" "/etc/${COMPONENT}/log4j.properties"
+dub template "/etc/confluent/docker/admin.properties.template" "/etc/${COMPONENT}/admin.properties"

--- a/debian/schema-registry/include/etc/confluent/docker/ensure
+++ b/debian/schema-registry/include/etc/confluent/docker/ensure
@@ -26,7 +26,8 @@ echo "===> Check if Kafka is healthy ..."
 
 if [[ -n "${SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL-}" ]] && [[ $SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL = "SSL" ]]
 then
-    cub kafka-ready 1 \
+    cub kafka-ready \
+        "${SCHEMA_REGISTRY_CUB_KAFKA_MIN_BROKERS:-1}" \
         "${SCHEMA_REGISTRY_CUB_KAFKA_TIMEOUT:-40}" \
         -b "${SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS}" \
         --config /etc/"${COMPONENT}"/admin.properties


### PR DESCRIPTION
- Apply changes from #178 

**How did i test ?**

Run a SSL enabled Kafka cluster : http://docs.confluent.io/3.2.0/cp-docker-images/docs/tutorials/clustered-deployment-ssl.html

**Run 2 node cluster** 

```
docker run -d --net=host --name=sr-ssl-1 -e SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=localhost:22181,localhost:32181,localhost:42181 -e SCHEMA_REGISTRY_HOST_NAME=localhost -e SCHEMA_REGISTRY_LISTENERS=http://localhost:8083 -e SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=SSL://localhost:29092 -e SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL=SSL -e SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION=/etc/schema-registry/secrets/kafka.producer.keystore.jks -e SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD=confluent -e SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD=confluent -e SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_LOCATION=/etc/schema-registry/secrets/kafka.producer.truststore.jks -v /home/ubuntu/cp-docker-images/examples/kafka-cluster-ssl/secrets:/etc/schema-registry/secrets confluentinc/cp-schema-registry:3.2.0
```
```
docker run -d --net=host --name=sr-ssl-2 -e SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=localhost:22181,localhost:32181,localhost:42181 -e SCHEMA_REGISTRY_HOST_NAME=localhost -e SCHEMA_REGISTRY_LISTENERS=http://localhost:8082 -e SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=SSL://localhost:29092 -e SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL=SSL -e SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION=/etc/schema-registry/secrets/kafka.producer.keystore.jks -e SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD=confluent -e SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD=confluent -e SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_LOCATION=/etc/schema-registry/secrets/kafka.producer.truststore.jks -v /home/ubuntu/cp-docker-images/examples/kafka-cluster-ssl/secrets:/etc/schema-registry/secrets confluentinc/cp-schema-registry:3.2.0
```


**Run through quickstart**

```
docker exec -it sr-ssl-1 bash
```
```
  curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
    --data '{"schema": "{\"type\": \"string\"}"}' \
    http://localhost:8083/subjects/Kafka-key/versions
```

`curl -X GET http://localhost:8083/subjects` got Kafka-Key as output 

**Verify on 2nd node**

`docker exec -it sr-ssl-2 bash`

`curl -X GET http://localhost:8082/subjects` got Kafka-Key as output 