### PR TITLE
Fix SSL issue for Rest Proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD_NUMBER := 3
+BUILD_NUMBER := 4
 CP_VERSION := 3.2.0
 VERSION := ${CP_VERSION}-${BUILD_NUMBER}
 COMPONENTS := base zookeeper kafka kafka-rest schema-registry kafka-connect-base kafka-connect enterprise-control-center kafkacat enterprise-replicator enterprise-kafka

--- a/debian/kafka-rest/include/etc/confluent/docker/admin.properties.template
+++ b/debian/kafka-rest/include/etc/confluent/docker/admin.properties.template
@@ -1,0 +1,4 @@
+{% set security_props = env_to_props('KAFKA_REST_CLIENT_', '') -%}
+{% for name, value in security_props.iteritems() -%}
+{{name}}={{value}}
+{% endfor -%}

--- a/debian/kafka-rest/include/etc/confluent/docker/configure
+++ b/debian/kafka-rest/include/etc/confluent/docker/configure
@@ -40,3 +40,4 @@ fi
 
 dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "/etc/${COMPONENT}/${COMPONENT}.properties"
 dub template "/etc/confluent/docker/log4j.properties.template" "/etc/${COMPONENT}/log4j.properties"
+dub template "/etc/confluent/docker/admin.properties.template" "/etc/${COMPONENT}/admin.properties"

--- a/debian/kafka-rest/include/etc/confluent/docker/ensure
+++ b/debian/kafka-rest/include/etc/confluent/docker/ensure
@@ -27,7 +27,7 @@ echo "===> Check if Kafka is healthy ..."
 if [[ -n "${KAFKA_REST_CLIENT_SECURITY_PROTOCOL-}" ]] && [[ $KAFKA_REST_CLIENT_SECURITY_PROTOCOL = "SSL" ]]
 then
     cub kafka-ready \
-        "${SCHEMA_REGISTRY_CUB_KAFKA_MIN_BROKERS:-1}" \
+        "${KAFKA_REST_CUB_KAFKA_MIN_BROKERS:-1}" \
         "${KAFKA_REST_CUB_KAFKA_TIMEOUT:-40}" \
         -b "${KAFKA_REST_BOOTSTRAP_SERVERS}" \
         --config /etc/"${COMPONENT}"/admin.properties

--- a/debian/kafka-rest/include/etc/confluent/docker/ensure
+++ b/debian/kafka-rest/include/etc/confluent/docker/ensure
@@ -23,12 +23,16 @@ echo "===> Check if Zookeeper is healthy ..."
 cub zk-ready "$KAFKA_REST_ZOOKEEPER_CONNECT" "${KAFKA_REST_CUB_ZK_TIMEOUT:-40}"
 
 echo "===> Check if Kafka is healthy ..."
-if [[ -n "${KAFKA_REST_SECURITY_PROTOCOL-}" ]] && [[ $KAFKA_REST_SECURITY_PROTOCOL="SSL" ]]
+
+cat /etc/"${COMPONENT}"/admin.properties
+
+if [[ -n "${KAFKA_REST_CLIENT_SECURITY_PROTOCOL-}" ]] && [[ $KAFKA_REST_CLIENT_SECURITY_PROTOCOL = "SSL" ]]
 then
-    cub kafka-ready 1 \
+    cub kafka-ready \
+        "${SCHEMA_REGISTRY_CUB_KAFKA_MIN_BROKERS:-1}" \
         "${KAFKA_REST_CUB_KAFKA_TIMEOUT:-40}" \
         -b "${KAFKA_REST_BOOTSTRAP_SERVERS}" \
-        --config /etc/"${COMPONENT}"/kafka-rest.properties
+        --config /etc/"${COMPONENT}"/admin.properties
 else
     cub kafka-ready \
         "${KAFKA_REST_CUB_KAFKA_MIN_BROKERS:-1}" \

--- a/debian/kafka-rest/include/etc/confluent/docker/ensure
+++ b/debian/kafka-rest/include/etc/confluent/docker/ensure
@@ -24,8 +24,6 @@ cub zk-ready "$KAFKA_REST_ZOOKEEPER_CONNECT" "${KAFKA_REST_CUB_ZK_TIMEOUT:-40}"
 
 echo "===> Check if Kafka is healthy ..."
 
-cat /etc/"${COMPONENT}"/admin.properties
-
 if [[ -n "${KAFKA_REST_CLIENT_SECURITY_PROTOCOL-}" ]] && [[ $KAFKA_REST_CLIENT_SECURITY_PROTOCOL = "SSL" ]]
 then
     cub kafka-ready \

--- a/debian/schema-registry/include/etc/confluent/docker/ensure
+++ b/debian/schema-registry/include/etc/confluent/docker/ensure
@@ -24,6 +24,8 @@ cub zk-ready "$SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL" "${SCHEMA_REGISTRY_CUB
 
 echo "===> Check if Kafka is healthy ..."
 
+cat /etc/"${COMPONENT}"/admin.properties
+
 if [[ -n "${SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL-}" ]] && [[ $SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL = "SSL" ]]
 then
     cub kafka-ready \

--- a/debian/schema-registry/include/etc/confluent/docker/ensure
+++ b/debian/schema-registry/include/etc/confluent/docker/ensure
@@ -24,8 +24,6 @@ cub zk-ready "$SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL" "${SCHEMA_REGISTRY_CUB
 
 echo "===> Check if Kafka is healthy ..."
 
-cat /etc/"${COMPONENT}"/admin.properties
-
 if [[ -n "${SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL-}" ]] && [[ $SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL = "SSL" ]]
 then
     cub kafka-ready \


### PR DESCRIPTION
- Add admin properties for kafka-ready.
- Increment build number.

**How did I test ?**
Run a SSL enabled Kafka cluster : http://docs.confluent.io/3.2.0/cp-docker-images/docs/tutorials/clustered-deployment-ssl.html

**Run Rest proxy**
```
docker run -d \
    --net=host \
    --name=kafka-rest \
    -e KAFKA_REST_ZOOKEEPER_CONNECT=localhost:32181 \
    -e KAFKA_REST_LISTENERS=https://localhost:8089 \
    -e KAFKA_REST_SCHEMA_REGISTRY_URL=http://localhost:8082 \
    -e KAFKA_REST_BOOTSTRAP_SERVERS="SSL://localhost:29092" \
    -e KAFKA_REST_HOST_NAME=localhost \
    -e KAFKA_REST_CLIENT_SECURITY_PROTOCOL=SSL \
    -e KAFKA_REST_CLIENT_SSL_KEYSTORE_LOCATION="/etc/kafka-rest/secrets/kafka.producer.keystore.jks" \
    -e KAFKA_REST_CLIENT_SSL_KEYSTORE_PASSWORD=confluent \
    -e KAFKA_REST_CLIENT_SSL_TRUSTSTORE_PASSWORD=confluent \
    -e KAFKA_REST_CLIENT_SSL_TRUSTSTORE_LOCATION="/etc/kafka-rest/secrets/kafka.producer.truststore.jks" \
    -e KAFKA_REST_SSL_KEYSTORE_LOCATION="/etc/kafka-rest/secrets/kafka.producer.keystore.jks" \
    -e KAFKA_REST_SSL_KEYSTORE_PASSWORD=confluent \
    -e KAFKA_REST_SSL_TRUSTSTORE_LOCATION="/etc/kafka-rest/secrets/kafka.producer.truststore.jks" \
    -e KAFKA_REST_SSL_TRUSTSTORE_PASSWORD=confluent \
    -e KAFKA_REST_SECURITY_PROTOCOL=SSL \
    -e KAFKA_REST_SSL_KEY_PASSWORD="" \
    -v ${KAFKA_SSL_SECRETS_DIR}:/etc/kafka-rest/secrets confluentinc/cp-kafka-rest:3.2.0
```
**Run the quickstart**
```    
docker exec -it kafka-rest bash

curl -k -X POST -H "Content-Type: application/vnd.kafka.json.v2+json" \
      -H "Accept: application/vnd.kafka.v2+json" \
      --data '{"records":[{"value":{"foo":"bar"}}]}' "https://localhost:8089/topics/jsontest1"


curl -k -X POST -H "Content-Type: application/vnd.kafka.v2+json" \
      --data '{"name": "my_consumer_instance", "format": "json", "auto.offset.reset": "earliest"}' \
      https://localhost:8089/consumers/my_json_consumer

curl -k -X POST -H "Content-Type: application/vnd.kafka.v2+json" --data '{"topics":["jsontest1"]}' \
 https://localhost:8089/consumers/my_json_consumer/instances/my_consumer_instance/subscription

curl -k -X GET -H "Accept: application/vnd.kafka.json.v2+json" \
      https://localhost:8089/consumers/my_json_consumer/instances/my_consumer_instance/records
```