### PR TITLE
Pass environment variables to topic metrics settings

### DIFF
--- a/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
@@ -7,10 +7,6 @@ confluent.monitoring.interceptor.topic.replication={{env.get('CONTROL_CENTER_MON
 confluent.controlcenter.internal.topics.replication={{env.get('CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 confluent.controlcenter.command.topic.replication={{env.get('CONTROL_CENTER_COMMAND_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 
-confluent.metrics.topic.partitions={{env.get('CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS', env['CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS'])}}
-confluent.metrics.topic.replication={{env.get('CONTROL_CENTER_COMMAND_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
-
-
 {# optional properties #}
 {% set other_props = {
     'CONTROL_CENTER_ID': 'confluent.controlcenter.id',
@@ -22,6 +18,8 @@ confluent.metrics.topic.replication={{env.get('CONTROL_CENTER_COMMAND_TOPIC_REPL
     'CONTROL_CENTER_INTERNAL_TOPICS_RETENTION_MS': 'confluent.controlcenter.internal.topics.retention.ms',
     'CONTROL_CENTER_INTERNAL_TOPICS_CHANGELOG_SEGEMENT_BYTES': 'confluent.controlcenter.internal.topics.changelog.segment.bytes',
     'CONTROL_CENTER_LICENSE': 'confluent.controlcenter.license',
+    'CONFLUENT_METRICS_TOPIC_PARTITION': 'confluent.metrics.topic.partitions',
+    'CONFLUENT_METRICS_TOPIC_REPLICATION': 'confluent.metrics.topic.replication',
 } -%}
 
 {% set excludes = other_props.keys() + ['CONTROL_CENTER_COMMAND_TOPIC_REPLICATION'] -%}

--- a/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
@@ -7,6 +7,9 @@ confluent.monitoring.interceptor.topic.replication={{env.get('CONTROL_CENTER_MON
 confluent.controlcenter.internal.topics.replication={{env.get('CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 confluent.controlcenter.command.topic.replication={{env.get('CONTROL_CENTER_COMMAND_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 
+confluent.metrics.topic.partitions={{env.get('CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS', env['CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS'])}}
+confluent.metrics.topic.replication={{env.get('CONTROL_CENTER_COMMAND_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
+
 
 {# optional properties #}
 {% set other_props = {


### PR DESCRIPTION
This change patches an issue I ran into when starting the control-center container in the Docker Quickstart (http://docs.confluent.io/current/cp-docker-images/docs/quickstart.html). Please let me know if there's a better place to make this fix.

Log and stacktrace for the original issue:
```
#Ignoring Mesos override errors
. /etc/confluent/docker/apply-mesos-overrides || true
+ . /etc/confluent/docker/apply-mesos-overrides
#!/usr/bin/env bash
#
# Copyright 2016 Confluent Inc.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
#
# Mesos DC/OS docker deployments will have HOST and PORT0 
# set for the proxying of the service.  We need to
# make sure that we don't override PORT, which is used
# when setting control-center properties.
#
# DC/OS will set PORT_<port> to the proxy port when
# exposing an internal port via a Docker Bridge network;
# but it also sets PORT and PORT0 for the same values.
# 
# Use those values provide things we know we'll need.

[ -n "${PORT:-}" ] && [ -n "${PORT_9021:-}" ] && [ "$PORT" = "${PORT_9021}" ] &&\
	export PORT=9021 || true
++ '[' -n '' ']'
++ true


echo "===> ENV Variables ..."
+ echo '===> ENV Variables ...'
===> ENV Variables ...
env | sort
+ sort
+ env
APT_ALLOW_UNAUTHENTICATED=false
COMPONENT=control-center
CONFLUENT_DEB_VERSION=1
CONFLUENT_MAJOR_VERSION=3
CONFLUENT_MINOR_VERSION=2
CONFLUENT_PATCH_VERSION=1
CONFLUENT_VERSION=3.2.1
CONTROL_CENTER_BOOTSTRAP_SERVERS=localhost:29092
CONTROL_CENTER_CONFIG_DIR=/etc/confluent-control-center
CONTROL_CENTER_CONNECT_CLUSTER=http://localhost:28082
CONTROL_CENTER_DATA_DIR=/var/lib/confluent-control-center
CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS=1
CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS=1
CONTROL_CENTER_REPLICATION_FACTOR=1
CONTROL_CENTER_STREAMS_NUM_STREAM_THREADS=1
CONTROL_CENTER_ZOOKEEPER_CONNECT=localhost:32181
HOME=/root
HOSTNAME=confluent
KAFKA_VERSION=0.10.2.1
LANG=C.UTF-8
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PWD=/
PYTHON_PIP_VERSION=8.1.2
PYTHON_VERSION=2.7.9-1
SCALA_VERSION=2.11
SHLVL=1
TERM=xterm
ZULU_OPENJDK_VERSION=8=8.17.0.3
_=/usr/bin/env

echo "===> User"
+ echo '===> User'
===> User
id
+ id
uid=0(root) gid=0(root) groups=0(root)

echo "===> Configuring ..."
+ echo '===> Configuring ...'
===> Configuring ...
/etc/confluent/docker/configure
+ /etc/confluent/docker/configure

dub ensure CONTROL_CENTER_BOOTSTRAP_SERVERS
+ dub ensure CONTROL_CENTER_BOOTSTRAP_SERVERS
dub ensure CONTROL_CENTER_ZOOKEEPER_CONNECT
+ dub ensure CONTROL_CENTER_ZOOKEEPER_CONNECT
dub ensure CONTROL_CENTER_DATA_DIR
+ dub ensure CONTROL_CENTER_DATA_DIR
dub ensure CONTROL_CENTER_REPLICATION_FACTOR
+ dub ensure CONTROL_CENTER_REPLICATION_FACTOR
dub ensure CONTROL_CENTER_CONFIG_DIR
+ dub ensure CONTROL_CENTER_CONFIG_DIR

echo "===> Check if ${CONTROL_CENTER_CONFIG_DIR} is writable ..."
+ echo '===> Check if /etc/confluent-control-center is writable ...'
===> Check if /etc/confluent-control-center is writable ...
dub path "${CONTROL_CENTER_CONFIG_DIR}" writable
+ dub path /etc/confluent-control-center writable

echo "===> Check if ${CONTROL_CENTER_DATA_DIR} is writable ..."
+ echo '===> Check if /var/lib/confluent-control-center is writable ...'
===> Check if /var/lib/confluent-control-center is writable ...
dub path "${CONTROL_CENTER_DATA_DIR}" writable
+ dub path /var/lib/confluent-control-center writable

dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "${CONTROL_CENTER_CONFIG_DIR}/${COMPONENT}.properties"
+ dub template /etc/confluent/docker/control-center.properties.template /etc/confluent-control-center/control-center.properties
dub template "/etc/confluent/docker/log4j.properties.template" "${CONTROL_CENTER_CONFIG_DIR}/log4j.properties"
+ dub template /etc/confluent/docker/log4j.properties.template /etc/confluent-control-center/log4j.properties
dub template "/etc/confluent/docker/admin.properties.template" "${CONTROL_CENTER_CONFIG_DIR}/admin.properties"
+ dub template /etc/confluent/docker/admin.properties.template /etc/confluent-control-center/admin.properties

echo "===> Running preflight checks ... "
+ echo '===> Running preflight checks ... '
===> Running preflight checks ... 
/etc/confluent/docker/ensure
+ /etc/confluent/docker/ensure

echo "===> Check if Zookeeper is healthy ..."
+ echo '===> Check if Zookeeper is healthy ...'
===> Check if Zookeeper is healthy ...
cub zk-ready "$CONTROL_CENTER_ZOOKEEPER_CONNECT" "${CONTROL_CENTER_CUB_ZK_TIMEOUT:-40}"
+ cub zk-ready localhost:32181 40
Client environment:zookeeper.version=3.4.6-1569965, built on 02/20/2014 09:09 GMT
Client environment:host.name=confluent
Client environment:java.version=1.8.0_102
Client environment:java.vendor=Azul Systems, Inc.
Client environment:java.home=/usr/lib/jvm/zulu-8-amd64/jre
Client environment:java.class.path=/etc/confluent/docker/docker-utils.jar
Client environment:java.library.path=/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib
Client environment:java.io.tmpdir=/tmp
Client environment:java.compiler=<NA>
Client environment:os.name=Linux
Client environment:os.arch=amd64
Client environment:os.version=4.4.66-boot2docker
Client environment:user.name=root
Client environment:user.home=/root
Client environment:user.dir=/
Initiating client connection, connectString=localhost:32181 sessionTimeout=40000 watcher=io.confluent.admin.utils.ZookeeperConnectionWatcher@14514713
Opening socket connection to server confluent/127.0.0.1:32181. Will not attempt to authenticate using SASL (unknown error)
Socket connection established to confluent/127.0.0.1:32181, initiating session
Session establishment complete on server confluent/127.0.0.1:32181, sessionid = 0x15beee6ee770013, negotiated timeout = 40000
Session: 0x15beee6ee770013 closed
EventThread shut down

echo "===> Check if Kafka is healthy ..."
+ echo '===> Check if Kafka is healthy ...'
===> Check if Kafka is healthy ...

cub kafka-ready "${CONTROL_CENTER_REPLICATION_FACTOR}" \
  "${CONTROL_CENTER_CUB_KAFKA_TIMEOUT:-40}" \
  -b "${CONTROL_CENTER_BOOTSTRAP_SERVERS}" \
  --config "${CONTROL_CENTER_CONFIG_DIR}/admin.properties"
+ cub kafka-ready 1 40 -b localhost:29092 --config /etc/confluent-control-center/admin.properties
MetadataClientConfig values: 
	bootstrap.servers = [localhost:29092]
	max.poll.timeout.ms = 5000
	sasl.jaas.config = null
	sasl.kerberos.kinit.cmd = /usr/bin/kinit
	sasl.kerberos.min.time.before.relogin = 60000
	sasl.kerberos.service.name = null
	sasl.kerberos.ticket.renew.jitter = 0.05
	sasl.kerberos.ticket.renew.window.factor = 0.8
	sasl.mechanism = GSSAPI
	security.protocol = PLAINTEXT
	ssl.cipher.suites = null
	ssl.enabled.protocols = [TLSv1.2, TLSv1.1, TLSv1]
	ssl.endpoint.identification.algorithm = null
	ssl.key.password = null
	ssl.keymanager.algorithm = SunX509
	ssl.keystore.location = null
	ssl.keystore.password = null
	ssl.keystore.type = JKS
	ssl.protocol = TLS
	ssl.provider = null
	ssl.secure.random.implementation = null
	ssl.trustmanager.algorithm = PKIX
	ssl.truststore.location = null
	ssl.truststore.password = null
	ssl.truststore.type = JKS


echo "===> Launching ... "
+ echo '===> Launching ... '
===> Launching ... 
exec /etc/confluent/docker/launch
+ exec /etc/confluent/docker/launch
===> Launching control-center ... 
[2017-05-09 20:51:50,106] INFO ControlCenterConfig values: 
	confluent.controlcenter.internal.topics.retention.bytes = -1
	confluent.controlcenter.command.streams.start.timeout = 300000
	confluent.controlcenter.internal.streams.start.timeout = 3600000
	confluent.controlcenter.connect.timeout.ms = 15000
	bootstrap.servers = [localhost:29092]
	confluent.controlcenter.rest.advertised.url = 
	confluent.controlcenter.streams.consumer.max.poll.records = 10000
	confluent.controlcenter.mail.from = c3@confluent.io
	confluent.controlcenter.internal.topics.retention.ms = 86400000
	confluent.monitoring.interceptor.topic.config.validate = false
	confluent.metrics.topic.config.validate = false
	confluent.controlcenter.connect.cluster = [http://localhost:28082]
	confluent.metrics.topic.partitions = 12
	confluent.metrics.topic.retention.bytes = -1
	confluent.monitoring.interceptor.topic.retention.ms = 259200000
	confluent.controlcenter.mail.port = 587
	confluent.metrics.topic.replication = 3
	confluent.monitoring.interceptor.topic = _confluent-monitoring
	confluent.controlcenter.rest.port = 9021
	confluent.controlcenter.streams.consumer.request.timeout.ms = 30001
	confluent.controlcenter.id = 1
	zookeeper.connect = localhost:32181
	confluent.metrics.topic = _confluent-metrics
	confluent.controlcenter.rest.compression.enable = true
	confluent.controlcenter.command.topic = _confluent-command
	confluent.controlcenter.internal.topics.replication = 1
	confluent.controlcenter.internal.topics.partitions = 1
	confluent.controlcenter.command.topic.retention.bytes = -1
	confluent.controlcenter.mail.host.name = localhost
	confluent.controlcenter.alert.max.trigger.events = 1000
	confluent.controlcenter.mail.password = 
	confluent.controlcenter.data.dir = /var/lib/confluent-control-center
	confluent.license = 
	confluent.controlcenter.name = _confluent-controlcenter-3-2-1
	confluent.controlcenter.streams.producer.retries = 2147483647
	confluent.controlcenter.mail.enabled = false
	confluent.controlcenter.command.topic.retention.ms = 259200000
	confluent.monitoring.interceptor.topic.retention.bytes = -1
	confluent.controlcenter.streams.producer.retry.backoff.ms = 100
	confluent.controlcenter.internal.topics.changelog.segment.bytes = 134217728
	confluent.controlcenter.mail.username = 
	confluent.controlcenter.streams.num.stream.threads = 1
	confluent.controlcenter.command.topic.replication = 1
	confluent.controlcenter.mail.ssl.checkserveridentity = false
	confluent.controlcenter.connect.bootstrap.servers = []
	confluent.controlcenter.mail.bounce.address = 
	confluent.monitoring.interceptor.topic.replication = 1
	confluent.controlcenter.streams.consumer.session.timeout.ms = 30000
	confluent.metrics.topic.retention.ms = 259200000
	confluent.controlcenter.connect.zookeeper.connect = 
	confluent.controlcenter.mail.starttls.required = false
	confluent.monitoring.interceptor.topic.partitions = 1
	confluent.controlcenter.streams.producer.compression.type = lz4
 (io.confluent.controlcenter.ControlCenterConfig)
[2017-05-09 20:51:51,105] INFO StreamsConfig values: 
	application.id = _confluent-controlcenter-3-2-1-1
	application.server = 
	bootstrap.servers = [localhost:29092]
	buffered.records.per.partition = 100
	cache.max.bytes.buffering = 0
	client.id = 
	commit.interval.ms = 30000
	connections.max.idle.ms = 540000
	key.serde = class org.apache.kafka.common.serialization.Serdes$ByteArraySerde
	metadata.max.age.ms = 300000
	metric.reporters = []
	metrics.num.samples = 2
	metrics.recording.level = INFO
	metrics.sample.window.ms = 30000
	num.standby.replicas = 0
	num.stream.threads = 1
	partition.grouper = class org.apache.kafka.streams.processor.DefaultPartitionGrouper
	poll.ms = 100
	receive.buffer.bytes = 32768
	reconnect.backoff.ms = 50
	replication.factor = 1
	request.timeout.ms = 40000
	retry.backoff.ms = 100
	rocksdb.config.setter = class io.confluent.controlcenter.streams.RocksDBConfigurator
	security.protocol = PLAINTEXT
	send.buffer.bytes = 131072
	state.cleanup.delay.ms = 60000
	state.dir = /var/lib/confluent-control-center/1/kafka-streams
	timestamp.extractor = class io.confluent.controlcenter.streams.WindowExtractor
	value.serde = class org.apache.kafka.common.serialization.Serdes$ByteArraySerde
	windowstore.changelog.additional.retention.ms = 86400000
	zookeeper.connect = localhost:32181
 (org.apache.kafka.streams.StreamsConfig)
[2017-05-09 20:51:51,375] INFO setting topic names _confluent-monitoring _confluent-controlcenter-3-2-1-1-monitoring-aggregate-rekey _confluent-controlcenter-3-2-1-1-group-aggregate-topic-FIFTEEN_SECONDS (io.confluent.controlcenter.streams.WindowExtractor)
[2017-05-09 20:51:51,410] INFO ProducerConfig values: 
	acks = all
	batch.size = 16384
	block.on.buffer.full = false
	bootstrap.servers = [localhost:29092]
	buffer.memory = 33554432
	client.id = confluent-control-center-heartbeat-sender-1-producer
	compression.type = lz4
	connections.max.idle.ms = 540000
	interceptor.classes = []
	key.serializer = class org.apache.kafka.common.serialization.ByteArraySerializer
	linger.ms = 10
	max.block.ms = 60000
	max.in.flight.requests.per.connection = 1
	max.request.size = 10485760
	metadata.fetch.timeout.ms = 60000
	metadata.max.age.ms = 300000
	metric.reporters = []
	metrics.num.samples = 2
	metrics.sample.window.ms = 30000
	partitioner.class = class org.apache.kafka.clients.producer.internals.DefaultPartitioner
	receive.buffer.bytes = 32768
	reconnect.backoff.ms = 50
	request.timeout.ms = 30000
	retries = 10
	retry.backoff.ms = 500
	sasl.jaas.config = null
	sasl.kerberos.kinit.cmd = /usr/bin/kinit
	sasl.kerberos.min.time.before.relogin = 60000
	sasl.kerberos.service.name = null
	sasl.kerberos.ticket.renew.jitter = 0.05
	sasl.kerberos.ticket.renew.window.factor = 0.8
	sasl.mechanism = GSSAPI
	security.protocol = PLAINTEXT
	send.buffer.bytes = 131072
	ssl.cipher.suites = null
	ssl.enabled.protocols = [TLSv1.2, TLSv1.1, TLSv1]
	ssl.endpoint.identification.algorithm = null
	ssl.key.password = null
	ssl.keymanager.algorithm = SunX509
	ssl.keystore.location = null
	ssl.keystore.password = null
	ssl.keystore.type = JKS
	ssl.protocol = TLS
	ssl.provider = null
	ssl.secure.random.implementation = null
	ssl.trustmanager.algorithm = PKIX
	ssl.truststore.location = null
	ssl.truststore.password = null
	ssl.truststore.type = JKS
	timeout.ms = 30000
	value.serializer = class org.apache.kafka.common.serialization.ByteArraySerializer
 (org.apache.kafka.clients.producer.ProducerConfig)
[2017-05-09 20:51:51,456] INFO Kafka version : 0.10.2.1-cp1 (org.apache.kafka.common.utils.AppInfoParser)
[2017-05-09 20:51:51,456] INFO Kafka commitId : 4332ed2a2fbf1bcd (org.apache.kafka.common.utils.AppInfoParser)
[2017-05-09 20:51:51,530] INFO RestConfig values: 
	metric.reporters = []
	ssl.client.auth = false
	response.mediatype.default = application/json
	authentication.realm = 
	ssl.keystore.type = JKS
	ssl.trustmanager.algorithm = 
	authentication.method = NONE
	metrics.jmx.prefix = rest-utils
	request.logger.name = io.confluent.rest-utils.requests
	ssl.key.password = 
	ssl.truststore.password = 
	authentication.roles = [*]
	metrics.num.samples = 2
	ssl.endpoint.identification.algorithm = 
	compression.enable = true
	ssl.protocol = TLS
	debug = false
	listeners = []
	ssl.provider = 
	ssl.enabled.protocols = []
	shutdown.graceful.ms = 1000
	ssl.keystore.location = 
	response.mediatype.preferred = [application/json]
	ssl.cipher.suites = []
	ssl.truststore.type = JKS
	access.control.allow.methods = 
	access.control.allow.origin = 
	ssl.truststore.location = 
	ssl.keystore.password = 
	ssl.keymanager.algorithm = 
	port = 9021
	metrics.sample.window.ms = 30000
 (io.confluent.rest.RestConfig)
[2017-05-09 20:51:51,650] INFO Starting Control Center version=3.2.1 (io.confluent.controlcenter.ControlCenter)
[2017-05-09 20:51:51,914] INFO found topic=_confluent-command with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,929] INFO found topic=_confluent-controlcenter-3-2-1-1-monitoring-aggregate-rekey-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,929] INFO found topic=_confluent-controlcenter-3-2-1-1-group-aggregate-topic-ONE_HOUR-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,929] INFO found topic=_confluent-controlcenter-3-2-1-1-TriggerActionsStore-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,929] INFO found topic=_confluent-controlcenter-3-2-1-1-group-aggregate-topic-ONE_WEEK-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,930] INFO found topic=_confluent-controlcenter-3-2-1-1-MonitoringTriggerStore-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,930] INFO found topic=_confluent-controlcenter-3-2-1-1-TriggerEventsStore-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,930] INFO found topic=_confluent-controlcenter-3-2-1-1-aggregate-topic-partition-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,930] INFO found topic=_confluent-controlcenter-3-2-1-1-group-aggregate-topic-FIFTEEN_SECONDS-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,930] INFO found topic=_confluent-controlcenter-3-2-1-1-MonitoringVerifierStore-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,930] INFO found topic=_confluent-controlcenter-3-2-1-1-AlertHistoryStore-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,938] INFO found topic=_confluent-controlcenter-3-2-1-1-aggregatedTopicPartitionTableWindows-ONE_HOUR-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,938] INFO found topic=_confluent-controlcenter-3-2-1-1-MonitoringStream-FIFTEEN_SECONDS-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,938] INFO found topic=_confluent-controlcenter-3-2-1-1-KSTREAM-OUTEROTHER-0000000108-store-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,939] INFO found topic=_confluent-controlcenter-3-2-1-1-aggregatedTopicPartitionTableWindows-ONE_WEEK-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,939] INFO found topic=_confluent-controlcenter-3-2-1-1-MonitoringMessageAggregatorWindows-ONE_HOUR-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,939] INFO found topic=_confluent-controlcenter-3-2-1-1-Group-FIFTEEN_SECONDS-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,939] INFO found topic=_confluent-controlcenter-3-2-1-1-MonitoringMessageAggregatorWindows-FIFTEEN_SECONDS-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,939] INFO found topic=_confluent-controlcenter-3-2-1-1-KSTREAM-OUTERTHIS-0000000107-store-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,939] INFO found topic=_confluent-controlcenter-3-2-1-1-MonitoringStream-ONE_WEEK-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,940] INFO found topic=_confluent-controlcenter-3-2-1-1-aggregatedTopicPartitionTableWindows-FIFTEEN_SECONDS-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,940] INFO found topic=_confluent-controlcenter-3-2-1-1-Group-ONE_WEEK-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,941] INFO found topic=_confluent-controlcenter-3-2-1-1-MonitoringMessageAggregatorWindows-ONE_WEEK-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,941] INFO found topic=_confluent-controlcenter-3-2-1-1-MetricsAggregateStore-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,941] INFO found topic=_confluent-controlcenter-3-2-1-1-MonitoringStream-ONE_HOUR-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,941] INFO found topic=_confluent-controlcenter-3-2-1-1-Group-ONE_HOUR-changelog with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,947] INFO found topic=_confluent-controlcenter-3-2-1-1-actual-group-consumption-rekey with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-metrics-trigger-measurement-rekey with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-group-aggregate-topic-ONE_HOUR with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-group-aggregate-topic-ONE_WEEK with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-error-topic with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-monitoring-trigger-event-rekey with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-group-stream-extension-rekey with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-aggregate-topic-partition with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-group-aggregate-topic-FIFTEEN_SECONDS with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-cluster-rekey with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-monitoring-message-rekey with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-expected-group-consumption-rekey with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,948] INFO found topic=_confluent-controlcenter-3-2-1-1-monitoring-aggregate-rekey with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,954] INFO found topic=_confluent-controlcenter-3-2-1-1-MetricsAggregateStore-repartition with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:51,972] INFO found topic=_confluent-monitoring with partitions=1 (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:52,288] ERROR attempt=failed to create topic=_confluent-metrics partitions=12 replication=3 minIsr=2 retention=259200000 Error(error=INVALID_REPLICATION_FACTOR, message=replication factor: 3 larger than available brokers: 1) (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:52,292] ERROR attempt=failed to create topic=_confluent-metrics partitions=12 replication=3 minIsr=2 retention=259200000 Error(error=INVALID_REPLICATION_FACTOR, message=replication factor: 3 larger than available brokers: 1) (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:52,296] ERROR attempt=failed to create topic=_confluent-metrics partitions=12 replication=3 minIsr=2 retention=259200000 Error(error=INVALID_REPLICATION_FACTOR, message=replication factor: 3 larger than available brokers: 1) (io.confluent.controlcenter.KafkaHelper)
[2017-05-09 20:51:52,296] ERROR failed to create necessary topics (io.confluent.controlcenter.ControlCenter)
```