### PR TITLE
ST-394: we now tag our jenkins images with this label, so we get build errors  on jenkins. be more constrained

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean-containers:
 	docker volume ls -q -f dangling=true | xargs docker volume rm || true;
 
 clean-images:
-	for image in `docker images -q -f label=io.confluent.docker | uniq` ; do \
+	for image in `docker images -q -f label=io.confluent.docker.build.number | uniq` ; do \
         echo "Removing image $${image} \n==========================================\n " ; \
 				docker rmi -f $${image} || exit 1 ; \
   done
@@ -64,7 +64,7 @@ tag-remote:
 ifndef DOCKER_REMOTE_REPOSITORY
 	$(error DOCKER_REMOTE_REPOSITORY must be defined.)
 endif
-	for image in `docker images -f label=io.confluent.docker -f "dangling=false" --format "{{.Repository}}:{{.Tag}}"` ; do \
+	for image in `docker images -f label=io.confluent.docker.build.number -f "dangling=false" --format "{{.Repository}}:{{.Tag}}"` ; do \
         echo "\n Tagging $${image} as ${DOCKER_REMOTE_REPOSITORY}/$${image#*/}"; \
         docker tag $${image} ${DOCKER_REMOTE_REPOSITORY}/$${image#*/}; \
   done
@@ -73,7 +73,7 @@ push-private: clean build-debian build-test-images tag-remote
 ifndef DOCKER_REMOTE_REPOSITORY
 	$(error DOCKER_REMOTE_REPOSITORY must be defined.)
 endif
-	for image in `docker images -f label=io.confluent.docker -f "dangling=false" --format "{{.Repository}}:{{.Tag}}" | grep $$DOCKER_REMOTE_REPOSITORY` ; do \
+	for image in `docker images -f label=io.confluent.docker.build.number -f "dangling=false" --format "{{.Repository}}:{{.Tag}}" | grep $$DOCKER_REMOTE_REPOSITORY` ; do \
         echo "\n Pushing $${image}"; \
         docker push $${image}; \
   done

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -120,7 +120,7 @@ To get started, you can build all the CP images as follows:
 
 You can run build tests by running ``make test-build``.  Use this when you want to test the builds with a clean slate.  This deletes all images and starts from scratch.
 
-.. _running_tests : 
+.. _running_tests :
 
 Running Tests
 ~~~~~~~~~~~~~
@@ -149,9 +149,9 @@ Make Targets
 
 Delete all images tagged with ``label=io.confluent.docker.testing=true`` :
 
-``clean-images`` 
+``clean-images``
 
-Delete all containers tagged with ``label=io.confluent.docker`` :
+Delete all containers tagged with ``label=io.confluent.docker.build.number`` :
 
 ``clean-containers``
 
@@ -173,7 +173,7 @@ Extending the Docker Images
 --------------------------
 
 You may want to extend the images to add new software, change the
-config management, use service discovery etc.  This page provides instructions for doing so. 
+config management, use service discovery etc.  This page provides instructions for doing so.
 
 .. _prerequisites :
 
@@ -192,9 +192,9 @@ Prerequisites
 Adding Connectors to the Kafka Connect Image
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are currently two ways to add new connectors to the Kafka Connect image.  
+There are currently two ways to add new connectors to the Kafka Connect image.
 
-* Build a new Docker image that has connector installed. You can follow example 2 in the documentation below. You will need to make sure that the connector jars are on the classpath. 
+* Build a new Docker image that has connector installed. You can follow example 2 in the documentation below. You will need to make sure that the connector jars are on the classpath.
 * Add the connector jars via volumes.  If you don't want to create a new Docker image, please see our documentation on `Configuring Kafka Connect with External Jars <operations/external-volumes.html>`_ to configure the `cp-kafka-connect` container with external jars.
 
 .. _examples :
@@ -741,7 +741,7 @@ The following properties may be configured when using the ``kafka-ready`` utilit
   * Default: "PKIX"
   * Importance: low
 
-.. _references : 
+.. _references :
 
 References
 ----------


### PR DESCRIPTION
`io.confluent.docker.build.number` may not be the greatest thing to use for this, but it is a label we only set in `cp-docker-images`