### PR TITLE
We are missing the new metrics config

### DIFF
--- a/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
@@ -35,6 +35,7 @@ confluent.metrics.topic.replication={{env.get('CONTROL_CENTER_METRICS_TOPIC_REPL
 {{name}}={{value}}
 {% endfor -%}
 
+{# NOTE: the env var prefix is CONTROL_CENTER_METRICS_ but the property prefix is confluent.metrics. #}
 {% set metrics_props = env_to_props('CONTROL_CENTER_METRICS_', 'confluent.metrics.', exclude=excludes) -%}
 {% for name, value in metrics_props.iteritems() -%}
 {{name}}={{value}}

--- a/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
@@ -6,6 +6,7 @@ confluent.controlcenter.data.dir={{env['CONTROL_CENTER_DATA_DIR']}}
 confluent.monitoring.interceptor.topic.replication={{env.get('CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 confluent.controlcenter.internal.topics.replication={{env.get('CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 confluent.controlcenter.command.topic.replication={{env.get('CONTROL_CENTER_COMMAND_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
+confluent.controlcenter.metrics.topic.replication={{env.get('CONTROL_CENTER_METRICS_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 
 
 {# optional properties #}
@@ -21,7 +22,7 @@ confluent.controlcenter.command.topic.replication={{env.get('CONTROL_CENTER_COMM
     'CONTROL_CENTER_LICENSE': 'confluent.controlcenter.license',
 } -%}
 
-{% set excludes = other_props.keys() + ['CONTROL_CENTER_COMMAND_TOPIC_REPLICATION'] -%}
+{% set excludes = other_props.keys() + ['CONTROL_CENTER_COMMAND_TOPIC_REPLICATION', 'CONTROL_CENTER_METRICS_TOPIC_REPLICATION'] -%}
 
 {% for k, property in other_props.iteritems() -%}
 {% if env.get(k) != None -%}

--- a/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
@@ -34,8 +34,8 @@ confluent.controlcenter.command.topic.replication={{env.get('CONTROL_CENTER_COMM
 {{name}}={{value}}
 {% endfor -%}
 
-{% set command_props = env_to_props('CONTROL_CENTER_METRICS_', 'confluent.controlcenter.metmrics.', exclude=excludes) -%}
-{% for name, value in command_props.iteritems() -%}
+{% set metrics_props = env_to_props('CONTROL_CENTER_METRICS_', 'confluent.controlcenter.metmrics.', exclude=excludes) -%}
+{% for name, value in metrics_props.iteritems() -%}
 {{name}}={{value}}
 {% endfor -%}
 

--- a/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
@@ -34,6 +34,11 @@ confluent.controlcenter.command.topic.replication={{env.get('CONTROL_CENTER_COMM
 {{name}}={{value}}
 {% endfor -%}
 
+{% set command_props = env_to_props('CONTROL_CENTER_METRICS_', 'confluent.controlcenter.metmrics.', exclude=excludes) -%}
+{% for name, value in command_props.iteritems() -%}
+{{name}}={{value}}
+{% endfor -%}
+
 {% set connect_props = env_to_props('CONTROL_CENTER_CONNECT_', 'confluent.controlcenter.connect.', exclude=excludes) -%}
 {% for name, value in connect_props.iteritems() -%}
 {{name}}={{value}}

--- a/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
@@ -34,7 +34,7 @@ confluent.controlcenter.command.topic.replication={{env.get('CONTROL_CENTER_COMM
 {{name}}={{value}}
 {% endfor -%}
 
-{% set metrics_props = env_to_props('CONTROL_CENTER_METRICS_', 'confluent.controlcenter.metmrics.', exclude=excludes) -%}
+{% set metrics_props = env_to_props('CONTROL_CENTER_METRICS_', 'confluent.controlcenter.metrics.', exclude=excludes) -%}
 {% for name, value in metrics_props.iteritems() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
@@ -6,7 +6,7 @@ confluent.controlcenter.data.dir={{env['CONTROL_CENTER_DATA_DIR']}}
 confluent.monitoring.interceptor.topic.replication={{env.get('CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 confluent.controlcenter.internal.topics.replication={{env.get('CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 confluent.controlcenter.command.topic.replication={{env.get('CONTROL_CENTER_COMMAND_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
-confluent.controlcenter.metrics.topic.replication={{env.get('CONTROL_CENTER_METRICS_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
+confluent.metrics.topic.replication={{env.get('CONTROL_CENTER_METRICS_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 
 
 {# optional properties #}
@@ -35,7 +35,7 @@ confluent.controlcenter.metrics.topic.replication={{env.get('CONTROL_CENTER_METR
 {{name}}={{value}}
 {% endfor -%}
 
-{% set metrics_props = env_to_props('CONTROL_CENTER_METRICS_', 'confluent.controlcenter.metrics.', exclude=excludes) -%}
+{% set metrics_props = env_to_props('CONTROL_CENTER_METRICS_', 'confluent.metrics.', exclude=excludes) -%}
 {% for name, value in metrics_props.iteritems() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/tests/test_control_center.py
+++ b/tests/test_control_center.py
@@ -62,6 +62,7 @@ class ConfigTest(unittest.TestCase):
         confluent.monitoring.interceptor.topic.replication=1
         confluent.controlcenter.internal.topics.replication=1
         confluent.controlcenter.command.topic.replication=1
+        confluent.metrics.topic.replication=1
         """)
         self.assertEquals(expected, props)
 
@@ -76,6 +77,7 @@ class ConfigTest(unittest.TestCase):
         confluent.controlcenter.data.dir=/var/lib/confluent-control-center
         confluent.monitoring.interceptor.topic.replication=1
         confluent.controlcenter.internal.topics.replication=1
+        confluent.metrics.topic.replication=1
         confluent.controlcenter.command.topic.replication=3
         confluent.controlcenter.command.topic.retention.ms=1000
         confluent.controlcenter.connect.timeout=30000


### PR DESCRIPTION
There does not appear to be a way to change the replication factor for the metrics topic. This is problematic if you plan to start a cluster with less than 3 brokers