### PR TITLE
Kafka Streams docker demo: work without a VM on Macs

### DIFF
--- a/docs/tutorials/kafka-streams-examples.rst
+++ b/docs/tutorials/kafka-streams-examples.rst
@@ -53,20 +53,6 @@ If you want to see an appetizer of what we will do in this section, take a look 
 
 Ready now?  Let's start!
 
-.. note::
-
-    **Mac users only:** Create and configure the Docker Machine
-
-    .. sourcecode:: bash
-
-      # If you haven't done so, create a VM with 6GB of memory
-      # as your Docker Machine and name it `confluent`.
-      $ docker-machine create --driver virtualbox --virtualbox-memory 6000 confluent
-
-      # Next, configure your terminal window to attach it to your new Docker Machine.
-      $ eval $(docker-machine env confluent)
-
-
 Clone the Confluent Docker Images repository:
 
   .. sourcecode:: bash
@@ -77,8 +63,8 @@ Clone the Confluent Docker Images repository:
     # Change into the directory for this tutorial
     $ cd cp-docker-images/examples/kafka-streams-examples
 
-    # Switch to the `3.2.x` branch
-    $ git checkout 3.2.x
+    # Switch to the `v3.2.1` branch
+    $ git checkout v3.2.1
 
 Now we can launch the Kafka Music demo application including the services it depends on such as Kafka.
 
@@ -97,10 +83,6 @@ the Kafka Music application by accessing its REST API.
 
 .. sourcecode:: bash
 
-    # Mac users
-    $ curl -sXGET http://`docker-machine ip confluent`:7070/kafka-music/instances
-
-    # Linux users
     $ curl -sXGET http://localhost:7070/kafka-music/instances
 
     # You should see output similar to following, though here
@@ -122,10 +104,6 @@ the Kafka Music application by accessing its REST API.
 
 .. sourcecode:: bash
 
-    # Mac and Windows users
-    $ curl -sXGET http://`docker-machine ip confluent`:7070/kafka-music/charts/top-five
-
-    # Linux users
     $ curl -sXGET http://localhost:7070/kafka-music/charts/top-five
 
     # You should see output similar to following, though here
@@ -176,7 +154,7 @@ easily run any of these applications from inside the container via a command sim
     $ docker-compose exec kafka-music-application \
             java -cp /app/streams-examples-3.2.1-standalone.jar \
             io.confluent.examples.streams.WordCountLambdaExample \
-            localhost:29092
+            kafka:29092
 
 Of course you can also modify the tutorial's ``docker-compose.yml`` for repeatable deployments.
 
@@ -185,33 +163,21 @@ https://github.com/confluentinc/examples).  These instructions include, for exam
 input and output topics.  Also, each demo application supports CLI arguments.  Typically, the first CLI argument is
 the ``bootstrap.servers`` parameter and the second argument, if any, is the ``schema.registry.url`` setting.
 
-Available endpoints **from within the containers**:
+Available endpoints **from within the containers** as well as **on your host machine**:
 
-+---------------------------+-------------------------+---------------------------+
-| Endpoint                  | Parameter               | Value                     |
-+===========================+=========================+===========================+
-| Kafka Cluster             | ``bootstrap.servers``   | ``localhost:29092``       |
-+---------------------------+-------------------------+---------------------------+
-| Confluent Schema Registry | ``schema.registry.url`` | ``http://localhost:8081`` |
-+---------------------------+-------------------------+---------------------------+
-| ZooKeeper ensemble        | ``zookeeper.connect``   | ``localhost:32181``       |
-+---------------------------+-------------------------+---------------------------+
++---------------------------+-------------------------+---------------------------------+--------------------------------+
+| Endpoint                  | Parameter               | Value (from within containers)  | Value (from your host machine) |
++===========================+=========================+=================================+================================+
+| Kafka Cluster             | ``bootstrap.servers``   | ``kafka:29092``                 | ``localhost:29092``            |
++---------------------------+-------------------------+---------------------------------+--------------------------------+
+| Confluent Schema Registry | ``schema.registry.url`` | ``http://schema-registry:8081`` | ``http://localhost:8081``      |
++---------------------------+-------------------------+---------------------------------+--------------------------------+
+| ZooKeeper ensemble        | ``zookeeper.connect``   | ``zookeeper:32181``             | ``localhost:32181``            |
++---------------------------+-------------------------+---------------------------------+--------------------------------+
 
 The ZooKeeper endpoint is not required by Kafka Streams applications, but you need it to e.g.
 :ref:`manually create new Kafka topics <docker-tutorial_kafka-streams-examples_topics-create>` or to
 :ref:`list available Kafka topics <docker-tutorial_kafka-streams-examples_topics-list>`.
-
-Lastly, if you want to interact with the Kafka broker *from your host*, then on operating systems that require the use
-of Docker Machine (Mac OS and Windows OS) you must first override the environment variable ``KAFKA_ADVERTISED_IP`` to
-the IP address of the Docker Machine VM before starting the services via ``docker-compose up -d``:
-
-.. sourcecode:: bash
-
-    # Set `KAFKA_ADVERTISED_IP` to the IP address of the Docker Machine if the latter is actually available.
-    $ KAFKA_ADVERTISED_IP=`docker-machine ip confluent 2>/dev/null || echo localhost` docker-compose up -d
-
-You do not need to override the environment variable for interacting with other services such as ZooKeeper or Confluent
-Schema Registry.  See the tutorial's ``docker-compose.yml`` for further information.
 
 
 .. _docker-tutorial_kafka-streams-examples_appendix:
@@ -225,14 +191,6 @@ Appendix
 Inspecting the input topics of the Kafka Music application
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-.. note::
-
-    **Mac users only:** Configure your terminal to attach to the ``confluent`` Docker Machine.
-
-    .. sourcecode:: bash
-
-      $ eval $(docker-machine env confluent)
-
 Inspect the "play-events" input topic, which contains messages in Avro format:
 
 .. sourcecode:: bash
@@ -240,7 +198,7 @@ Inspect the "play-events" input topic, which contains messages in Avro format:
     # Use the kafka-avro-console-consumer to read the "play-events" topic
     $ docker-compose exec schema-registry \
         kafka-avro-console-consumer \
-            --zookeeper localhost:32181 \
+            --bootstrap-server kafka:29092 \
             --topic play-events --from-beginning
 
     # You should see output similar to:
@@ -258,7 +216,7 @@ Inspect the "song-feed" input topic, which contains messages in Avro format:
     # Use the kafka-avro-console-consumer to read the "song-feed" topic
     $ docker-compose exec schema-registry \
         kafka-avro-console-consumer \
-            --zookeeper localhost:32181 \
+            --bootstrap-server kafka:29092 \
             --topic song-feed --from-beginning
 
     # You should see output similar to:
@@ -279,7 +237,7 @@ You can create topics manually with the ``kafka-topics`` CLI tool, which is avai
 
    # Create a new topic named "my-new-topic", using the `kafka` container
    $ docker-compose exec kafka kafka-topics \
-       --zookeeper localhost:32181 \
+       --zookeeper zookeeper:32181 \
        --create --topic my-new-topic --partitions 2 --replication-factor 1
 
   # You should see a line similar to:
@@ -295,9 +253,9 @@ You can list all available topics with the ``kafka-topics`` CLI tool, which is a
 
 .. sourcecode:: bash
 
-   # Create a new topic named "my-new-topic", using the `kafka` container
+   # List available topics, using the `kafka` container
    $ docker-compose exec kafka kafka-topics \
-       --zookeeper localhost:32181 \
+       --zookeeper zookeeper:32181 \
        --list
 
 Additional topic information is displayed by running ``--describe`` instead of ``-list``.

--- a/examples/kafka-streams-examples/.env
+++ b/examples/kafka-streams-examples/.env
@@ -1,1 +1,0 @@
-KAFKA_ADVERTISED_IP=localhost

--- a/examples/kafka-streams-examples/docker-compose.yml
+++ b/examples/kafka-streams-examples/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: confluentinc/cp-kafka:3.2.1
+    image: confluentinc/cp-enterprise-kafka:3.2.1
     hostname: kafka
     ports:
       - '29092:29092'
@@ -22,6 +22,12 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
+      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: kafka:29092
+      CONFLUENT_METRICS_REPORTER_ZOOKEEPER_CONNECT: zookeeper:32181
+      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
+      CONFLUENT_METRICS_ENABLE: 'true'
+      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
     image: confluentinc/cp-schema-registry:3.2.1

--- a/examples/kafka-streams-examples/docker-compose.yml
+++ b/examples/kafka-streams-examples/docker-compose.yml
@@ -3,49 +3,37 @@ version: '2'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:3.2.1
-    network_mode: host
+    hostname: zookeeper
+    ports:
+      - '32181:32181'
     environment:
       ZOOKEEPER_CLIENT_PORT: 32181
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
     image: confluentinc/cp-kafka:3.2.1
-    network_mode: host
+    hostname: kafka
+    ports:
+      - '29092:29092'
     depends_on:
       - zookeeper
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: localhost:32181
-      # If you want to interact with the Kafka broker *from your host*, then on
-      # operating systems that require the use of Docker Machine (Mac OS and Windows OS)
-      # you must first override the environment variable KAFKA_ADVERTISED_IP to the
-      # IP address of the Docker Machine VM before starting the services via
-      # `docker-compose up -d`.
-      #
-      # You do not need to override the environment variable for interacting with the
-      # Kafka Music application, ZooKeeper, or Confluent Schema Registry.
-      #
-      # For example, if the Docker Machine is named "confluent":
-      #
-      #    $ KAFKA_ADVERTISED_IP=`docker-machine ip confluent 2>/dev/null || echo localhost` docker-compose up -d
-      #
-      # The default value is set in the `.env` file in this directory because
-      # in the Docker Compose v2.0 file format, the `${VARIABLE:-defaultValue}`
-      # syntax is not supported yet.
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://${KAFKA_ADVERTISED_IP}:29092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
 
   schema-registry:
     image: confluentinc/cp-schema-registry:3.2.1
-    network_mode: host
+    hostname: schema-registry
     depends_on:
       - zookeeper
       - kafka
     ports:
-      - '8081'
+      - '8081:8081'
     environment:
-      SCHEMA_REGISTRY_HOST_NAME: localhost
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: localhost:32181
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:32181
 
   # This "container" is a workaround to pre-create topics for the Kafka Music application
   # until we have a more elegant way to do that.
@@ -53,16 +41,16 @@ services:
     image: confluentinc/cp-kafka:3.2.1
     depends_on:
       - kafka
-    network_mode: host
+    hostname: kafka-create-topics
     # We defined a dependency on "kafka", but `depends_on` will NOT wait for the
     # dependencies to be "ready" before starting the "kafka-create-topics"
     # container;  it waits only until the dependencies have started.  Hence we
     # must control startup order more explicitly.
     # See https://docs.docker.com/compose/startup-order/
     command: "bash -c 'echo Waiting for Kafka to be ready... && \
-                       cub kafka-ready -b localhost:29092 1 20 && \
-                       kafka-topics --create --topic play-events --if-not-exists --zookeeper localhost:32181 --partitions 4 --replication-factor 1 && \
-                       kafka-topics --create --topic song-feed --if-not-exists --zookeeper localhost:32181 --partitions 4 --replication-factor 1 && \
+                       cub kafka-ready -b kafka:29092 1 20 && \
+                       kafka-topics --create --topic play-events --if-not-exists --zookeeper zookeeper:32181 --partitions 4 --replication-factor 1 && \
+                       kafka-topics --create --topic song-feed --if-not-exists --zookeeper zookeeper:32181 --partitions 4 --replication-factor 1 && \
                        sleep infinity'"
     environment:
       # The following settings are listed here only to satisfy the image's requirements.
@@ -73,19 +61,19 @@ services:
   # Continuously generates input data for the Kafka Music application.
   kafka-music-data-generator:
     image: confluentinc/cp-kafka-streams-examples:3.2.1
-    network_mode: host
+    hostname: kafka-music-data-generator
     depends_on:
       - kafka
       - schema-registry
       - kafka-create-topics
     # Control startup order similarly to the "kafka-create-topics" container above.
     command: "bash -c 'echo Waiting for Kafka to be ready... && \
-                       cub kafka-ready -b localhost:29092 1 20 && \
+                       cub kafka-ready -b kafka:29092 1 20 && \
                        echo Waiting for Confluent Schema Registry to be ready... && \
-                       cub sr-ready localhost 8081 20 && \
+                       cub sr-ready schema-registry 8081 20 && \
                        java -cp /app/streams-examples-3.2.1-standalone.jar \
                        io.confluent.examples.streams.interactivequeries.kafkamusic.KafkaMusicExampleDriver \
-                       localhost:29092 http://localhost:8081'"
+                       kafka:29092 http://schema-registry:8081'"
     environment:
       STREAMS_BOOTSTRAP_SERVERS: ignored
       STREAMS_SCHEMA_REGISTRY_HOST: ignored
@@ -96,7 +84,7 @@ services:
   # Runs the Kafka Music application.
   kafka-music-application:
     image: confluentinc/cp-kafka-streams-examples:3.2.1
-    network_mode: host
+    hostname: kafka-music-application
     depends_on:
       - kafka
       - schema-registry
@@ -110,17 +98,17 @@ services:
     # TODO: Once https://issues.apache.org/jira/browse/KAFKA-5037 is resolved,
     #       we can remove this `command` and use the image as-is.
     command: "bash -c 'echo Waiting for Kafka to be ready... && \
-                       cub kafka-ready -b localhost:29092 1 20 && \
+                       cub kafka-ready -b kafka:29092 1 20 && \
                        echo Waiting for Confluent Schema Registry to be ready... && \
-                       cub sr-ready localhost 8081 20 && \
+                       cub sr-ready schema-registry 8081 20 && \
                        echo Waiting a few seconds for topic creation to finish... && \
                        sleep 2 && \
                        /etc/confluent/docker/run'"
     ports:
-      - '7070'
+      - '7070:7070'
     environment:
-      STREAMS_BOOTSTRAP_SERVERS: localhost:29092
-      STREAMS_SCHEMA_REGISTRY_HOST: localhost
+      STREAMS_BOOTSTRAP_SERVERS: kafka:29092
+      STREAMS_SCHEMA_REGISTRY_HOST: schema-registry
       STREAMS_SCHEMA_REGISTRY_PORT: 8081
       KAFKA_MUSIC_APP_REST_HOST: localhost
       KAFKA_MUSIC_APP_REST_PORT: 7070


### PR DESCRIPTION
As discussed offline, this not only fixes the startup problems introduced by https://github.com/confluentinc/cp-docker-images/commit/1971b7d9198832bc8b3494712d0c604de961bf3f, but also allows us to get rid off the Docker Machine Linux VM when running on Macs.

This PR should also go (with appropriate versioning-related changes etc. where needed) into:

- `v3.2.1`
- `3.2.x`
- `master`

**Note:** The documentation in `kafka-streams-examples.rst` in this PR, which is based against `3.2.1-post`, refers to checking out the branch `v3.2.1` to get the correct `docker-compose.yml` file:

```shell
# Switch to the `v3.2.1` branch
$ git checkout v3.2.1
```

When we downmerge this PR to `3.2.x` and `master`, AFAICT we would need to update the branch reference accordingly, I think (not 100% sure, because the branch/naming convention is still a bit arcane to me :-P).  Also, perhaps the version tags for the docker images in `docker-compose.yml` would need updating, too, but I leave this to @aayars to figure out. :-)

**Follow-up task:** Once this PR is merged, we also need to re-publish the `/3.2.1/` and `/current/` docs so that http://docs.confluent.io/current/cp-docker-images/docs/tutorials/kafka-streams-examples.html and http://docs.confluent.io/3.2.1/cp-docker-images/docs/tutorials/kafka-streams-examples.html are updated with the new contents.