### PR TITLE
Allow accessing the Kafka broker via localhost:9092 from your Docker host machine

### DIFF
--- a/docs/tutorials/kafka-streams-examples.rst
+++ b/docs/tutorials/kafka-streams-examples.rst
@@ -168,7 +168,7 @@ Available endpoints **from within the containers** as well as **on your host mac
 +---------------------------+-------------------------+---------------------------------+--------------------------------+
 | Endpoint                  | Parameter               | Value (from within containers)  | Value (from your host machine) |
 +===========================+=========================+=================================+================================+
-| Kafka Cluster             | ``bootstrap.servers``   | ``kafka:29092``                 | ``localhost:29092``            |
+| Kafka Cluster             | ``bootstrap.servers``   | ``kafka:29092``                 | ``localhost:9092``             |
 +---------------------------+-------------------------+---------------------------------+--------------------------------+
 | Confluent Schema Registry | ``schema.registry.url`` | ``http://schema-registry:8081`` | ``http://localhost:8081``      |
 +---------------------------+-------------------------+---------------------------------+--------------------------------+

--- a/examples/kafka-streams-examples/docker-compose.yml
+++ b/examples/kafka-streams-examples/docker-compose.yml
@@ -14,13 +14,16 @@ services:
     image: confluentinc/cp-enterprise-kafka:3.2.1
     hostname: kafka
     ports:
+      - '9092:9092'
       - '29092:29092'
     depends_on:
       - zookeeper
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
       CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: kafka:29092


### PR DESCRIPTION
This allows host-to-container communication (e.g. Mac laptop to running `kafka` container) via `localhost:9092`, in addition to inter-container communication to the Kafka broker via `kafka:29092`

**When merging into downstream branches**:  When merging into `v3.2.1` and further branches, this PR needs to add the following Docker setting to all containers:

```
     extra_hosts:
       - "moby:127.0.0.1"
```
I can provide this in a separate PR against `v3.2.1`, but I suppose we want to follow the normal merge-downwards approach...?