### PR TITLE
Fix handling for basic auth in `check_http_ready`

### DIFF
--- a/debian/base/include/dub
+++ b/debian/base/include/dub
@@ -145,16 +145,16 @@ def check_http_ready(url, timeout):
     if not parsed.netloc:
         print("URL %s is malformed." % (url,), file=sys.stderr)
         sys.exit(1)
-    splitted = parsed.netloc.split(":", 1)
-    host = "localhost"
-    if len(splitted) > 0:
-      host = parsed.netloc.split(":", 1)[0]
+
     port = 80
-    if len(splitted) > 1:
-      port = parsed.netloc.split(":", 1)[1]
+    host = "localhost"
+    if parsed.port:
+        port = parsed.port
+        host = parsed.netloc[:parsed.netloc.rfind(":")]
     else:
-      if parsed.scheme == "https":
-        port = 443
+        host = parsed.netloc
+        if parsed.scheme == "https":
+            port = 443
 
     # Check if you can connect to the endpoint
     status = wait_for_service(host, port, timeout)


### PR DESCRIPTION
If you use basic authentication when connecting to a schema registry in `CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL`, Kafka Connect fails to start because it improperly parses the host and port when using basic authentication in `check_http_ready`.

For a small local test to recreate the issue, you can use `http://user:password@localhost:8081` as the schema registry URL. This causes the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/cub", line 297, in <module>
    success = check_schema_registry_ready(args.host, args.port, int(args.timeout))
  File "/usr/local/bin/cub", line 182, in check_schema_registry_ready
    status = wait_for_service(host, port, service_timeout)
  File "/usr/local/bin/cub", line 62, in wait_for_service
    s = socket.create_connection((host, int(port)), float(timeout))
ValueError: invalid literal for int() with base 10: 'password@localhost'
```