### PR TITLE
Corrected whitespace to be consistent with surrounding lines

### DIFF
--- a/debian/kafka-connect-base/include/etc/confluent/docker/run
+++ b/debian/kafka-connect-base/include/etc/confluent/docker/run
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 set -o nounset \
-		-o errexit \
+    -o errexit \
     -o verbose \
     -o xtrace
 


### PR DESCRIPTION
This pull request (PR) corrects the whitespace on a set call to make command consistent with those around it.