### PR TITLE
added kafka tools to the confluent control centre image

### DIFF
--- a/debian/enterprise-control-center/Dockerfile
+++ b/debian/enterprise-control-center/Dockerfile
@@ -34,7 +34,7 @@ EXPOSE 9021
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update && apt-get install -y confluent-${COMPONENT}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    \
+    && apt-get install confluent-kafka-${SCALA_VERSION}=${KAFKA_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     \


### PR DESCRIPTION
Without it, we can't run basic commands such as a kafka console consumer.