### PR TITLE
MMA-1686 setting CONTROL_CENTER_DATA_DIR is no longer required

### DIFF
--- a/debian/enterprise-control-center/Dockerfile
+++ b/debian/enterprise-control-center/Dockerfile
@@ -26,8 +26,6 @@ MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 
 ENV COMPONENT=control-center
-ENV CONTROL_CENTER_DATA_DIR=/var/lib/confluent-${COMPONENT}
-ENV CONTROL_CENTER_CONFIG_DIR=/etc/confluent-${COMPONENT}
 
 # Default listener
 EXPOSE 9021
@@ -39,8 +37,8 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     \
     && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
-    && chmod -R ag+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
+    && mkdir -p "/var/lib/confluent-${COMPONENT}" \
+    && chmod -R ag+w "/etc/confluent-${COMPONENT}" "/var/lib/confluent-${COMPONENT}"
 
 COPY include/etc/confluent/docker /etc/confluent/docker
 

--- a/debian/enterprise-control-center/Dockerfile.rpm
+++ b/debian/enterprise-control-center/Dockerfile.rpm
@@ -26,8 +26,6 @@ MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 
 ENV COMPONENT=control-center
-ENV CONTROL_CENTER_DATA_DIR=/var/lib/confluent-${COMPONENT}
-ENV CONTROL_CENTER_CONFIG_DIR=/etc/confluent-${COMPONENT}
 
 # Default listener
 EXPOSE 9021
@@ -39,8 +37,8 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && rm -rf /tmp/*  \
     \
     && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
-    && chmod -R ag+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
+    && mkdir -p "/var/lib/confluent-${COMPONENT}" \
+    && chmod -R ag+w "/etc/confluent-${COMPONENT}" "/var/lib/confluent-${COMPONENT}"
 
 COPY include/etc/confluent/docker /etc/confluent/docker
 

--- a/debian/enterprise-control-center/include/etc/confluent/docker/configure
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/configure
@@ -20,16 +20,15 @@ set -o nounset \
     -o xtrace
 
 dub ensure CONTROL_CENTER_BOOTSTRAP_SERVERS
-dub ensure CONTROL_CENTER_DATA_DIR
 dub ensure CONTROL_CENTER_REPLICATION_FACTOR
-dub ensure CONTROL_CENTER_CONFIG_DIR
 
-echo "===> Check if ${CONTROL_CENTER_CONFIG_DIR} is writable ..."
-dub path "${CONTROL_CENTER_CONFIG_DIR}" writable
+echo "===> Check if /etc/confluent-${COMPONENT} is writable ..."
+dub path "/etc/confluent-${COMPONENT}" writable
 
+export CONTROL_CENTER_DATA_DIR=${CONTROL_CENTER_DATA_DIR:-"/var/lib/confluent-control-center"}
 echo "===> Check if ${CONTROL_CENTER_DATA_DIR} is writable ..."
 dub path "${CONTROL_CENTER_DATA_DIR}" writable
 
-dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "${CONTROL_CENTER_CONFIG_DIR}/${COMPONENT}.properties"
-dub template "/etc/confluent/docker/log4j.properties.template" "${CONTROL_CENTER_CONFIG_DIR}/log4j.properties"
-dub template "/etc/confluent/docker/admin.properties.template" "${CONTROL_CENTER_CONFIG_DIR}/admin.properties"
+dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "/etc/confluent-${COMPONENT}/${COMPONENT}.properties"
+dub template "/etc/confluent/docker/log4j.properties.template" "/etc/confluent-${COMPONENT}/log4j.properties"
+dub template "/etc/confluent/docker/admin.properties.template" "/etc/confluent-${COMPONENT}/admin.properties"

--- a/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
@@ -2,7 +2,6 @@
 {# required properties #}
 bootstrap.servers={{env['CONTROL_CENTER_BOOTSTRAP_SERVERS']}}
 zookeeper.connect={{env['CONTROL_CENTER_ZOOKEEPER_CONNECT']}}
-confluent.controlcenter.data.dir={{env['CONTROL_CENTER_DATA_DIR']}}
 confluent.monitoring.interceptor.topic.replication={{env.get('CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 confluent.controlcenter.internal.topics.replication={{env.get('CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
 confluent.controlcenter.command.topic.replication={{env.get('CONTROL_CENTER_COMMAND_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
@@ -12,6 +11,7 @@ confluent.metrics.topic.replication={{env.get('CONTROL_CENTER_METRICS_TOPIC_REPL
 {% set other_props = {
     'CONTROL_CENTER_ID': 'confluent.controlcenter.id',
     'CONTROL_CENTER_NAME': 'confluent.controlcenter.name',
+    'CONTROL_CENTER_DATA_DIR': 'confluent.controlcenter.data.dir',
     'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC': 'confluent.monitoring.interceptor.topic',
     'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS': 'confluent.monitoring.interceptor.topic.partitions',
     'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_RETENTION_MS': 'confluent.monitoring.interceptor.topic.retention.ms',

--- a/debian/enterprise-control-center/include/etc/confluent/docker/ensure
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/ensure
@@ -24,4 +24,4 @@ echo "===> Check if Kafka is healthy ..."
 cub kafka-ready "${CONTROL_CENTER_REPLICATION_FACTOR}" \
   "${CONTROL_CENTER_CUB_KAFKA_TIMEOUT:-40}" \
   -b "${CONTROL_CENTER_BOOTSTRAP_SERVERS}" \
-  --config "${CONTROL_CENTER_CONFIG_DIR}/admin.properties"
+  --config "/etc/confluent-${COMPONENT}/admin.properties"

--- a/debian/enterprise-control-center/include/etc/confluent/docker/launch
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/launch
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 echo "===> Launching ${COMPONENT} ... "
-exec "${COMPONENT}-start" "${CONTROL_CENTER_CONFIG_DIR}/${COMPONENT}.properties"
+exec "${COMPONENT}-start" "/etc/confluent-${COMPONENT}/${COMPONENT}.properties"

--- a/tests/test_control_center.py
+++ b/tests/test_control_center.py
@@ -58,7 +58,6 @@ class ConfigTest(unittest.TestCase):
         expected = props_to_list("""
         bootstrap.servers=kafka:9092
         zookeeper.connect=zookeeper:2181/defaultconfig
-        confluent.controlcenter.data.dir=/var/lib/confluent-control-center
         confluent.monitoring.interceptor.topic.replication=1
         confluent.controlcenter.internal.topics.replication=1
         confluent.controlcenter.command.topic.replication=1
@@ -74,7 +73,6 @@ class ConfigTest(unittest.TestCase):
         expected = props_to_list("""
         bootstrap.servers=kafka:9092
         zookeeper.connect=zookeeper:2181/defaultconfig
-        confluent.controlcenter.data.dir=/var/lib/confluent-control-center
         confluent.monitoring.interceptor.topic.replication=1
         confluent.controlcenter.internal.topics.replication=1
         confluent.metrics.topic.replication=1


### PR DESCRIPTION
* 4.0.x now defaults to /var/lib/confluent-control-center
* also remove CONTROL_CENTER_CONFIG_DIR to be more consistent with our other images