### PR TITLE
Use ensure command for kafka-rest

### DIFF
--- a/debian/kafka-rest/include/etc/confluent/docker/configure
+++ b/debian/kafka-rest/include/etc/confluent/docker/configure
@@ -19,7 +19,8 @@ set -o nounset \
     -o verbose \
     -o xtrace
 
-dub ensure-atleast-one KAFKA_REST_ZOOKEEPER_CONNECT KAFKA_REST_BOOTSTRAP_SERVERS
+dub ensure KAFKA_REST_ZOOKEEPER_CONNECT
+dub ensure KAFKA_REST_BOOTSTRAP_SERVERS
 dub ensure KAFKA_REST_HOST_NAME
 
 dub path /etc/"${COMPONENT}"/ writable


### PR DESCRIPTION
The [dub](https://github.com/confluentinc/cp-docker-images/blob/master/docs/development.rst#docker-utility-belt-dub) utility does not have a `ensure-atleast-one` argument. This was causing the REST Proxy to fail:

> `usage: dub [-h] {template,ensure,wait,http-ready,path} ...`
> `dub: error: argument action: invalid choice: 'ensure-atleast-one' (choose from 'template', 'ensure', 'wait', 'http-ready', 'path')`