### PR TITLE
Add optional ARG overrides of required ENV params during build time

### DIFF
--- a/debian/kafka/Dockerfile
+++ b/debian/kafka/Dockerfile
@@ -23,6 +23,12 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 
+# allow arg override of required env params
+ARG KAFKA_ZOOKEEPER_CONNECT
+ENV KAFKA_ZOOKEEPER_CONNECT=${KAFKA_ZOOKEEPER_CONNECT}
+ARG KAFKA_ADVERTISED_LISTENERS
+ENV KAFKA_ADVERTISED_LISTENERS=${KAFKA_ADVERTISED_LISTENERS}
+
 ENV COMPONENT=kafka
 
 # primary

--- a/debian/kafka/include/etc/confluent/docker/run
+++ b/debian/kafka/include/etc/confluent/docker/run
@@ -19,6 +19,16 @@ set -o nounset \
     -o verbose \
     -o xtrace
 
+
+# Set environment values if they exist as arguments
+if [ $# -ne 0 ]; then
+  echo "===> Overriding env params with args ..."
+  for var in "$@"
+  do
+    export "$var"
+  done
+fi
+
 echo "===> ENV Variables ..."
 env | sort
 


### PR DESCRIPTION
Adding flexibility to the Kafka Docker image to allow `ARG` overrides of the two required environment variables.

## Example usage:
```bash
docker build -t kafka \
  --build-arg KAFKA_ZOOKEEPER_CONNECT=localhost:2181 \
  --build-arg KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://test:9092  .
```

## Test:
Add `RUN echo $KAFKA_ADVERTISED_LISTENERS` in Dockerfile after proposed edits and build using example above. The console will display the passed-in value for that env param and you can omit it in the `-e ` args during runtime as it is already set.

## Helps with orchestration (i.e. Kubernetes)
This also solves a major issue with attempted Kubernetes deployments using this image, given the unique POD IP cannot be passed dynamically in the `ENV` parameters. By adding the ability to also declare these two required values (checked at startup by configure script), this image can be used with minor customization in Kubernetes.

Example (relevant snippet) Kubernetes config:
```yaml
      containers:
      - name: cp-kafka
        imagePullPolicy: Always
        image: confluentinc/cp-kafka:3.3.1
        resources:
          requests:
            memory: "4Gi"
            cpu: 0.5
        ports:
        - containerPort: 9092
          name: server
          protocol: TCP
        - containerPort: 49999
          name: jmx
          protocol: TCP
        lifecycle:
          postStart:
            exec:
              command:
                - "/bin/sh"
                - "-c"
                - "export KAFKA_BROKER_ID=${HOSTNAME##*-}"
        env:
          - name: KAFKA_ZOOKEEPER_CONNECT
            value: zk-cs.default.svc.cluster.local:2181
          - name: KAFKA_JMX_PORT
            value: "49999"
          - name: MY_POD_IP
            valueFrom:
              fieldRef:
                fieldPath: status.podIP
        args:
          - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://$(MY_POD_IP):9092
```