### PR TITLE
fix permission denied on /var/log/kafka/kafka-gc.log and /var/log/kaf…

### DIFF
--- a/debian/enterprise-kafka/Dockerfile
+++ b/debian/enterprise-kafka/Dockerfile
@@ -37,8 +37,8 @@ RUN echo "===> installing confluent-support-metrics ..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     \
 		&& echo "===> Setting up ${COMPONENT} dirs..." \
-   	&& mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
-   	&& chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets
+   	&& mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT} \
+   	&& chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT}
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
 

--- a/debian/kafka/Dockerfile
+++ b/debian/kafka/Dockerfile
@@ -35,8 +35,8 @@ RUN echo "===> installing ${COMPONENT}..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     \
 		&& echo "===> Setting up ${COMPONENT} dirs..." \
-   	&& mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
-   	&& chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets
+   	&& mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT} \
+   	&& chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT}
 
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]

--- a/debian/zookeeper/Dockerfile
+++ b/debian/zookeeper/Dockerfile
@@ -34,8 +34,8 @@ RUN echo "===> installing ${COMPONENT}..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     \
     && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
-    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets
+    && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets /var/log/kafka \
+    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets /var/log/kafka
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/var/lib/${COMPONENT}/log", "/etc/${COMPONENT}/secrets"]
 


### PR DESCRIPTION
Within a container orchestration platform (kubernetes/openshift), where docker images are not run as user 0, one does not have the proper permissions to write the following files:

    OpenJDK 64-Bit Server VM warning: Cannot open file /var/log/kafka/zookeeper-gc.log due to Permission denied
    OpenJDK 64-Bit Server VM warning: Cannot open file /var/log/kafka/kafkaServer-gc.log due to Permission denied

This pull request fixed the permissions issues on this folder and it's files.