### PR TITLE
Remove empty tutorials page

### DIFF
--- a/docs/tutorials/kafka-streams-examples.rst
+++ b/docs/tutorials/kafka-streams-examples.rst
@@ -1,7 +1,0 @@
-.. _docker-tutorial_kafka-streams-examples:
-
-Kafka Streams Examples
-----------------------
-
-`This content has moved. <http://docs.confluent.io/current/streams/kafka-streams-examples/docs/index.html>`_
-


### PR DESCRIPTION
Removes page that only contains redirect link. This is now done automatically. 

Related PR: https://github.com/confluentinc/docs/pull/727