### PR TITLE
[OpenShift] Fix permission denied when container runs as non-root random user

### DIFF
--- a/debian/enterprise-kafka/Dockerfile
+++ b/debian/enterprise-kafka/Dockerfile
@@ -37,8 +37,8 @@ RUN echo "===> installing confluent-support-metrics ..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     \
 		&& echo "===> Setting up ${COMPONENT} dirs..." \
-   	&& mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
-   	&& chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets
+   	&& mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT} \
+   	&& chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT}
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
 

--- a/debian/enterprise-kafka/Dockerfile.rpm
+++ b/debian/enterprise-kafka/Dockerfile.rpm
@@ -34,8 +34,8 @@ RUN echo "===> installing confluent-support-metrics ..." \
     && echo "===> clean up ..."  \
     && rm -rf /tmp/* \
     && echo "===> Setting up ${COMPONENT} dirs..." \
-   	&& mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
-   	&& chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets
+   	&& mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT} \
+   	&& chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT}
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
 

--- a/debian/enterprise-replicator/Dockerfile
+++ b/debian/enterprise-replicator/Dockerfile
@@ -28,6 +28,5 @@ RUN echo "===> Installing Replicator ..." \
     && apt-get -qq update \
      && apt-get install -y \
         confluent-kafka-connect-replicator=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-        confluent-support-metrics=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
      && echo "===> Cleaning up ..."  \
      && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*

--- a/debian/enterprise-replicator/Dockerfile
+++ b/debian/enterprise-replicator/Dockerfile
@@ -28,5 +28,6 @@ RUN echo "===> Installing Replicator ..." \
     && apt-get -qq update \
      && apt-get install -y \
         confluent-kafka-connect-replicator=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+        confluent-support-metrics=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
      && echo "===> Cleaning up ..."  \
      && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*

--- a/debian/kafka-connect-base/Dockerfile
+++ b/debian/kafka-connect-base/Dockerfile
@@ -33,6 +33,7 @@ RUN echo "===> Installing Schema Registry (for Avro jars) ..." \
     && apt-get -qq update \
     && apt-get install -y \
         confluent-schema-registry=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+        confluent-support-metrics=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..."\
     && apt-get install -y confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \

--- a/debian/kafka/Dockerfile
+++ b/debian/kafka/Dockerfile
@@ -41,8 +41,8 @@ RUN echo "===> installing ${COMPONENT}..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     \
 		&& echo "===> Setting up ${COMPONENT} dirs..." \
-   	&& mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
-   	&& chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets
+   	&& mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT} \
+   	&& chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT}
 
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]

--- a/debian/kafka/Dockerfile.rpm
+++ b/debian/kafka/Dockerfile.rpm
@@ -35,8 +35,8 @@ RUN echo "===> installing ${COMPONENT}..." \
     && rm -rf /tmp/* \
     \
     && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
-    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets
+    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT} \
+    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets /var/log/${COMPONENT}
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
 

--- a/debian/kafkacat/Dockerfile
+++ b/debian/kafkacat/Dockerfile
@@ -30,6 +30,14 @@ RUN echo "Building kafkacat ....." \
         libsasl2-modules-gssapi-mit \
         krb5-user \
         krb5-config \
+        wget \
+        curl \
+        dnsutils \
+        tcptraceroute \
+        hping3 \
+        nmap \
+        nc \
+        jq \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 CMD ["kafkacat"]

--- a/debian/schema-registry/Dockerfile
+++ b/debian/schema-registry/Dockerfile
@@ -40,8 +40,8 @@ RUN echo "===> installing ${COMPONENT}..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     \
     && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p /etc/${COMPONENT}/secrets\
-    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets
+    && mkdir -p /etc/${COMPONENT}/secrets /var/log/${COMPONENT} \
+    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /var/log/${COMPONENT}
 
 VOLUME ["/etc/${COMPONENT}/secrets"]
 

--- a/debian/zookeeper/Dockerfile
+++ b/debian/zookeeper/Dockerfile
@@ -34,8 +34,8 @@ RUN echo "===> installing ${COMPONENT}..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     \
     && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
-    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets
+    && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets /var/log/kafka \
+    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets /var/log/kafka
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/var/lib/${COMPONENT}/log", "/etc/${COMPONENT}/secrets"]
 

--- a/debian/zookeeper/Dockerfile.rpm
+++ b/debian/zookeeper/Dockerfile.rpm
@@ -34,8 +34,8 @@ RUN echo "===> installing ${COMPONENT}..." \
     && rm -rf /tmp/* \
     \
     && echo "===> Setting up ${COMPONENT} dirs" \
-    && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
-    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets
+    && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets /var/log/kafka \
+    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets /var/log/kafka
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/var/lib/${COMPONENT}/log", "/etc/${COMPONENT}/secrets"]
 


### PR DESCRIPTION
Within a container orchestration platform (kubernetes/openshift), where docker images are not run as user 0, one does not have the proper permissions to write the following files:

    OpenJDK 64-Bit Server VM warning: Cannot open file /var/log/kafka/zookeeper-gc.log due to Permission denied
    OpenJDK 64-Bit Server VM warning: Cannot open file /var/log/kafka/kafkaServer-gc.log due to Permission denied

This pull request fixed the permissions issues on this folder and it's files.

Original PR: https://github.com/confluentinc/cp-docker-images/pull/407