### PR TITLE
CC-1663: Added JMS connectors to Connect image

### DIFF
--- a/debian/kafka-connect/Dockerfile
+++ b/debian/kafka-connect/Dockerfile
@@ -34,5 +34,6 @@ RUN echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
         confluent-kafka-connect-elasticsearch=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
         confluent-kafka-connect-storage-common=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
         confluent-kafka-connect-s3=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+        confluent-kafka-connect-jms=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -97,7 +97,7 @@ Setup
          --amazonec2-region us-west-2 \
          --amazonec2-instance-type m4.large \
          --amazonec2-root-size 100 \
-         --amazonec2-ami ami-16b1a077 \
+         --amazonec2-ami ami-8f78c2f7 \
          --amazonec2-tags Name,$INSTANCE_NAME \
          $USER-aws-confluent
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -97,7 +97,7 @@ Setup
          --amazonec2-region us-west-2 \
          --amazonec2-instance-type m4.large \
          --amazonec2-root-size 100 \
-         --amazonec2-ami ami-8f78c2f7 \
+         --amazonec2-ami ami-16b1a077 \
          --amazonec2-tags Name,$INSTANCE_NAME \
          $USER-aws-confluent
 

--- a/tests/fixtures/debian/kafka-connect/distributed-single-node.yml
+++ b/tests/fixtures/debian/kafka-connect/distributed-single-node.yml
@@ -49,6 +49,12 @@ services:
     labels:
     - io.confluent.docker.testing=true
 
+  activemq-host:
+    image: webcenter/activemq:5.14.3
+    network_mode: host
+    labels:
+    - io.confluent.docker.testing=true
+
   connect-host-json:
     image: confluentinc/cp-kafka-connect:latest
     network_mode: host


### PR DESCRIPTION
Also added test for the ActiveMQ connector. The Docker image includes JMS connector, ActiveMQ connector, and IBM MQ connector, but it’s very difficult to add messages to MQ (no command line utility) and so it’s going to be tough to write tests.