### PR TITLE
MINOR: Fix unbound variable bug for KAFKA_SSL_CLIENT_AUTH

### DIFF
--- a/debian/kafka/include/etc/confluent/docker/configure
+++ b/debian/kafka/include/etc/confluent/docker/configure
@@ -85,7 +85,7 @@ then
   export KAFKA_SSL_KEYSTORE_PASSWORD
   KAFKA_SSL_KEYSTORE_PASSWORD=$(cat "$KAFKA_SSL_KEYSTORE_CREDENTIALS_LOCATION")
 
-  if [[ $KAFKA_SSL_CLIENT_AUTH == *"required"* ]] || [[ $KAFKA_SSL_CLIENT_AUTH == *"requested"* ]]
+  if [[ -n "${KAFKA_SSL_CLIENT_AUTH-}" ]] && ( [[ $KAFKA_SSL_CLIENT_AUTH == *"required"* ]] || [[ $KAFKA_SSL_CLIENT_AUTH == *"requested"* ]] )
   then
       dub ensure KAFKA_SSL_TRUSTSTORE_FILENAME
       export KAFKA_SSL_TRUSTSTORE_LOCATION="/etc/kafka/secrets/$KAFKA_SSL_TRUSTSTORE_FILENAME"


### PR DESCRIPTION
The line `if [[ $KAFKA_SSL_CLIENT_AUTH == *"required"* ]] || [[ $KAFKA_SSL_CLIENT_AUTH == *"requested"* ]]` causes an unbound variable error if the variable `$KAFKA_SSL_CLIENT_AUTH` is unset. This should fix that.