### PR TITLE
Adds a Docker HEALTHCHECK asking ZooKeeper ruok

### DIFF
--- a/debian/zookeeper/Dockerfile
+++ b/debian/zookeeper/Dockerfile
@@ -41,4 +41,6 @@ VOLUME ["/var/lib/${COMPONENT}/data", "/var/lib/${COMPONENT}/log", "/etc/${COMPO
 
 COPY include/etc/confluent/docker /etc/confluent/docker
 
+HEALTHCHECK CMD /etc/confluent/docker/health
+
 CMD ["/etc/confluent/docker/run"]

--- a/debian/zookeeper/include/etc/confluent/docker/health
+++ b/debian/zookeeper/include/etc/confluent/docker/health
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset \
+    -o errexit \
+    -o verbose \
+    -o xtrace
+
+ZOOKEEPER_CLIENT_PORT_ADDRESS="${ZOOKEEPER_CLIENT_PORT_ADDRESS:-127.0.0.1}"
+[ -z "${ZOOKEEPER_CLIENT_PORT:-}" ] && echo "ZOOKEEPER_CLIENT_PORT must be set" && exit 1
+
+ok=$(echo ruok | nc -vw5 ${ZOOKEEPER_CLIENT_PORT_ADDRESS} ${ZOOKEEPER_CLIENT_PORT})
+[ ${ok:-} == "imok" ] || exit 1


### PR DESCRIPTION
Adds a healthcheck to the ZooKeeper Docker image.  Asks ZooKeeper `ruok` and expects `imok`.  Binding address/port aware.

`HEALTHCHECK` implies building and running on Docker 1.12+.