### PR TITLE
added plugin path in examples for replicator

### DIFF
--- a/examples/enterprise-replicator/docker-compose.yml
+++ b/examples/enterprise-replicator/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       CONNECT_INTERNAL_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
       CONNECT_REST_ADVERTISED_HOST_NAME: "localhost"
       CONNECT_LOG4J_ROOT_LOGLEVEL: DEBUG
+      CONNECT_PLUGIN_PATH: /usr/share/java
     volumes:
       - /tmp/replicator-host-cluster-test/:/tmp/test
     extra_hosts:
@@ -120,6 +121,7 @@ services:
       CONNECT_INTERNAL_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
       CONNECT_REST_ADVERTISED_HOST_NAME: "localhost"
       CONNECT_LOG4J_ROOT_LOGLEVEL: DEBUG
+      CONNECT_PLUGIN_PATH: /usr/share/java
     volumes:
       - /tmp/replicator-host-cluster-test/:/tmp/test
     extra_hosts:


### PR DESCRIPTION
`CONNECT_PLUGIN_PATH: /usr/share/java` was missing