### PR TITLE
DOCS-405 - Correct usage of "its" vs "it's" in cp-docker-images

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -148,7 +148,7 @@ The Kafka image uses variables prefixed with ``KAFKA_`` with an underscore (``_`
 
   .. note::
 
-    You'll notice that we set the ``KAFKA_ADVERTISED_LISTENERS`` variable to ``localhost:29092``.  This is an important setting, as it will make Kafka accessible from outside the container by advertising it's location on the Docker host.
+    You'll notice that we set the ``KAFKA_ADVERTISED_LISTENERS`` variable to ``localhost:29092``.  This is an important setting, as it will make Kafka accessible from outside the container by advertising its location on the Docker host.
 
     Also notice that we set ``KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR`` to 1.  This is needed when you are running with a single-node cluster.  If you have three or more nodes, you do not need to change this from the default.
 
@@ -183,7 +183,7 @@ The Enterprise Kafka image includes the packages for Confluent Auto Data Balanci
 
   .. note::
 
-    You'll notice that we set the ``KAFKA_ADVERTISED_LISTENERS`` variable to ``localhost:29092``.  This is an important setting, as it will make Kafka accessible from outside the container by advertising it's location on the Docker host.
+    You'll notice that we set the ``KAFKA_ADVERTISED_LISTENERS`` variable to ``localhost:29092``.  This is an important setting, as it will make Kafka accessible from outside the container by advertising its location on the Docker host.
 
     If you want to enable Proactive support or use Confluent Auto Data Balancing features, please follow the Proactive support and ADB documentation at `Confluent documentation <http://docs.confluent.io/current/>`_.
 
@@ -260,7 +260,7 @@ The following settings must be passed to run the REST Proxy Docker image.
 
   Specifies the |zk| connection string in the form hostname:port where host and port are the host and port of a |zk| server. To allow connecting through other |zk| nodes when that |zk| machine is down you can also specify multiple hosts in the form hostname1:port1,hostname2:port2,hostname3:port3.
 
-  The server may also have a |zk| ``chroot`` path as part of it's |zk| connection string which puts its data under some path in the global |zk| namespace. If so the consumer should use the same chroot path in its connection string. For example to give a chroot path of /chroot/path you would give the connection string as ``hostname1:port1,hostname2:port2,hostname3:port3/chroot/path``.
+  The server may also have a |zk| ``chroot`` path as part of its |zk| connection string which puts its data under some path in the global |zk| namespace. If so the consumer should use the same chroot path in its connection string. For example to give a chroot path of /chroot/path you would give the connection string as ``hostname1:port1,hostname2:port2,hostname3:port3/chroot/path``.
 
 -------------
 Kafka Connect
@@ -377,7 +377,7 @@ The following settings must be passed to run the Confluent Control Center image.
 
   Specifies the |zk| connection string in the form hostname:port where host and port are the host and port of a |zk| server. To allow connecting through other |zk| nodes when that |zk| machine is down you can also specify multiple hosts in the form ``hostname1:port1,hostname2:port2,hostname3:port3``.
 
-  The server may also have a |zk| ``chroot`` path as part of it's |zk| connection string which puts its data under some path in the global |zk| namespace. If so the consumer should use the same chroot path in its connection string. For example to give a chroot path of /chroot/path you would give the connection string as ``hostname1:port1,hostname2:port2,hostname3:port3/chroot/path``.
+  The server may also have a |zk| ``chroot`` path as part of its |zk| connection string which puts its data under some path in the global |zk| namespace. If so the consumer should use the same chroot path in its connection string. For example to give a chroot path of /chroot/path you would give the connection string as ``hostname1:port1,hostname2:port2,hostname3:port3/chroot/path``.
 
 ``CONTROL_CENTER_BOOTSTRAP_SERVERS``
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -57,7 +57,7 @@ Launching the Process
 The ``launch`` script runs the actual process. The script should ensure
 that :
 
--  The process is run with process id 1. Your script should use ``exec`` so the program takes over the shell process rather than running as a child process.  This is so that your program will receive signals like SIGTERM directly rather than it's parent shell process receiving them.
+-  The process is run with process id 1. Your script should use ``exec`` so the program takes over the shell process rather than running as a child process.  This is so that your program will receive signals like SIGTERM directly rather than its parent shell process receiving them.
 -  Log to stdout
 
 Development Guidelines

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -269,7 +269,7 @@ Start Kafka.
           confluentinc/cp-kafka:4.1.0
 
   .. note::
-    You'll notice that the ``KAFKA_ADVERTISED_LISTENERS`` variable is set to ``localhost:29092``.  This will make Kafka accessible from outside the container by advertising it's location on the Docker host.  You also passed in the |zk| port that you used when launching that container a moment ago.   Because you are using ``--net=host``, the hostname for the |zk| service can be left at ``localhost``.
+    You'll notice that the ``KAFKA_ADVERTISED_LISTENERS`` variable is set to ``localhost:29092``.  This will make Kafka accessible from outside the container by advertising its location on the Docker host.  You also passed in the |zk| port that you used when launching that container a moment ago.   Because you are using ``--net=host``, the hostname for the |zk| service can be left at ``localhost``.
 
     Also notice that ``KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR`` is set to 1.  This is needed when you are running with a single-node cluster.  If you have three or more nodes, you do not need to change this from the default.
 
@@ -506,7 +506,7 @@ This portion of the quick start provides an overview of how to use Confluent Con
 
   You may notice that you have specified a URL for the Kafka Connect cluster that does not yet exist.  Not to worry, you'll work on that in the next section.
 
-  Control Center will create the topics it needs in Kafka.  Check that it started correctly by searching it's logs with the following command:
+  Control Center will create the topics it needs in Kafka.  Check that it started correctly by searching its logs with the following command:
 
   .. sourcecode:: console
 

--- a/docs/tutorials/connect-avro-jdbc.rst
+++ b/docs/tutorials/connect-avro-jdbc.rst
@@ -68,7 +68,7 @@ Now that we have all of the Docker dependencies installed, we can create a Docke
 
   .. note::
 
-    You'll notice that we set the ``KAFKA_ADVERTISED_LISTENERS`` variable to ``localhost:29092``.  This will make Kafka accessible from outside the container by advertising it's location on the Docker host.
+    You'll notice that we set the ``KAFKA_ADVERTISED_LISTENERS`` variable to ``localhost:29092``.  This will make Kafka accessible from outside the container by advertising its location on the Docker host.
 
     We are also overriding offsets.topic.replication.factor to 1 at runtime, since there is only one active broker in this example.
 


### PR DESCRIPTION
Fixes a few place where "it's" is mistakenly used instead of "its".