### PR TITLE
CC-2041. Added Confluent Hub client ot the Connect base image.

### DIFF
--- a/debian/kafka-connect-base/Dockerfile
+++ b/debian/kafka-connect-base/Dockerfile
@@ -35,6 +35,8 @@ RUN echo "===> Installing Schema Registry (for Avro jars) ..." \
         confluent-schema-registry=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..."\
     && apt-get install -y confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Installing Confluent Hub client ..."\
+    && apt-get install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     echo "===> Setting up ${COMPONENT} dirs ..." \


### PR DESCRIPTION
This PR installs Confluent Hub client in the base Connect image.
It will work only for 5.x, since the package is used, available only in 5.x.

Tested it locally by running:
```
	COMPONENTS="base kafka kafka-connect-base kafka-connect" \
	ALLOW_UNSIGNED=true \
	CONFLUENT_PACKAGES_REPO=https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/master/550 \
	    KAFKA_VERSION=2.0.0 \
	CONFLUENT_MVN_LABEL="-SNAPSHOT" \
	CONFLUENT_DEB_LABEL="~SNAPSHOT" \
	CONFLUENT_RPM_LABEL=-0.1.SNAPSHOT \
	CONFLUENT_MAJOR_VERSION=5 \
	CONFLUENT_MINOR_VERSION=0 \
	CONFLUENT_PATCH_VERSION=0 \
	CONFLUENT_VERSION=5.0.0 \
	VERSION=5.0.0-SNAPSHOT-550 \
	COMMIT_ID=b6d07ba \
	BUILD_NUMBER=550 \
	REPOSITORY=confluentinc \
	bin/build-debian
```