### PR TITLE
Remove redundant --new-consumer option

### DIFF
--- a/docs/tutorials/clustered-deployment-sasl.rst
+++ b/docs/tutorials/clustered-deployment-sasl.rst
@@ -335,7 +335,7 @@ This tutorial runs a secure three-node Kafka cluster and |zk| ensemble with SASL
         -v ${KAFKA_SASL_SECRETS_DIR}:/etc/kafka/secrets \
         -e KAFKA_OPTS="-Djava.security.auth.login.config=/etc/kafka/secrets/consumer_jaas.conf -Djava.security.krb5.conf=/etc/kafka/secrets/krb.conf" \
         confluentinc/cp-kafka:4.1.0 \
-        kafka-console-consumer --bootstrap-server quickstart.confluent.io:29094 --topic bar --new-consumer --from-beginning --consumer.config /etc/kafka/secrets/host.consumer.ssl.sasl.config
+        kafka-console-consumer --bootstrap-server quickstart.confluent.io:29094 --topic bar --from-beginning --consumer.config /etc/kafka/secrets/host.consumer.ssl.sasl.config
 
    You should see the following (it might take some time for this command to return data. Kafka has to create the ``__consumers_offset`` topic behind the scenes when you consume data for the first time and this may take some time):
 

--- a/docs/tutorials/clustered-deployment-ssl.rst
+++ b/docs/tutorials/clustered-deployment-ssl.rst
@@ -252,7 +252,7 @@ This tutorial runs a secure three-node Kafka cluster and |zk| ensemble with SSL.
         --rm \
         -v ${KAFKA_SSL_SECRETS_DIR}:/etc/kafka/secrets \
         confluentinc/cp-kafka:4.1.0 \
-        kafka-console-consumer --bootstrap-server localhost:29092 --topic bar --new-consumer --from-beginning --consumer.config /etc/kafka/secrets/host.consumer.ssl.config --max-messages 42
+        kafka-console-consumer --bootstrap-server localhost:29092 --topic bar --from-beginning --consumer.config /etc/kafka/secrets/host.consumer.ssl.config --max-messages 42
 
    You should see the following (it might take some time for this command to return data. Kafka has to create the ``__consumers_offset`` topic behind the scenes when you consume data for the first time and this may take some time):
 

--- a/docs/tutorials/clustered-deployment.rst
+++ b/docs/tutorials/clustered-deployment.rst
@@ -224,7 +224,7 @@ Now that we have all of the Docker dependencies installed, we can create a Docke
          --net=host \
          --rm \
          confluentinc/cp-kafka:4.1.0 \
-         kafka-console-consumer --bootstrap-server localhost:29092 --topic bar --new-consumer --from-beginning --max-messages 42
+         kafka-console-consumer --bootstrap-server localhost:29092 --topic bar --from-beginning --max-messages 42
 
    You should see the following (it might take some time for this command to return data. Kafka has to create the ``__consumers_offset``
    topic behind the scenes when you consume data for the first time and this may take some time):

--- a/docs/tutorials/connect-avro-jdbc.rst
+++ b/docs/tutorials/connect-avro-jdbc.rst
@@ -305,7 +305,7 @@ Now that we have all of the Docker dependencies installed, we can create a Docke
        --net=host \
        --rm \
        confluentinc/cp-schema-registry:4.1.0 \
-       kafka-avro-console-consumer --bootstrap-server localhost:29092 --topic quickstart-jdbc-test --new-consumer --from-beginning --max-messages 10
+       kafka-avro-console-consumer --bootstrap-server localhost:29092 --topic quickstart-jdbc-test --from-beginning --max-messages 10
 
    You should see the following:
 

--- a/docs/tutorials/replicator.rst
+++ b/docs/tutorials/replicator.rst
@@ -248,7 +248,7 @@ In this section, we provide a tutorial for running Replicator which replicates d
       --net=host \
       --rm \
       confluentinc/cp-kafka:4.1.0 \
-      kafka-console-consumer --bootstrap-server localhost:9072 --topic foo.replica --new-consumer --from-beginning --max-messages 1000
+      kafka-console-consumer --bootstrap-server localhost:9072 --topic foo.replica --from-beginning --max-messages 1000
 
    If everything is working as expected, each of the original messages we produced should be written back out:
 
@@ -353,7 +353,7 @@ In this section, we provide a tutorial for running Replicator which replicates d
       --net=host \
       --rm \
       confluentinc/cp-kafka:4.1.0 \
-      kafka-console-consumer --bootstrap-server localhost:9072 --topic bar.replica --new-consumer --from-beginning --max-messages 1000
+      kafka-console-consumer --bootstrap-server localhost:9072 --topic bar.replica --from-beginning --max-messages 1000
 
    .. sourcecode:: bash
 

--- a/tests/test_control_center.py
+++ b/tests/test_control_center.py
@@ -169,7 +169,7 @@ class StandaloneNetworkingTest(unittest.TestCase):
             && seq "$MESSAGES" | control-center-run-class kafka.tools.ConsoleProducer --broker-list "$BOOTSTRAP_SERVERS" --topic "$TOPIC" --producer-property interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor \
             && echo PRODUCED "$MESSAGES" messages. \
             && echo "interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor" > /tmp/consumer.config \
-            && control-center-run-class kafka.tools.ConsoleConsumer --bootstrap-server "$BOOTSTRAP_SERVERS" --topic "$TOPIC" --new-consumer --from-beginning --max-messages "$CHECK_MESSAGES" --consumer.config /tmp/consumer.config'
+            && control-center-run-class kafka.tools.ConsoleConsumer --bootstrap-server "$BOOTSTRAP_SERVERS" --topic "$TOPIC" --from-beginning --max-messages "$CHECK_MESSAGES" --consumer.config /tmp/consumer.config'
             """
 
         MESSAGES = 10000

--- a/tests/test_enterprise_replicator.py
+++ b/tests/test_enterprise_replicator.py
@@ -37,7 +37,7 @@ PRODUCE_DATA = """bash -c "\
 CONSUME_DATA = """bash -c "\
         export KAFKA_TOOLS_LOG4J_LOGLEVEL=DEBUG \
         && dub template "/etc/confluent/docker/tools-log4j.properties.template" "/etc/kafka/tools-log4j.properties" \
-        && kafka-console-consumer --bootstrap-server {brokers} --topic {topic} --new-consumer --from-beginning --max-messages {messages}"
+        && kafka-console-consumer --bootstrap-server {brokers} --topic {topic} --from-beginning --max-messages {messages}"
         """
 
 

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -47,7 +47,7 @@ PRODUCER = """bash -c "\
 CONSUMER = """bash -c "\
         export KAFKA_TOOLS_LOG4J_LOGLEVEL=DEBUG \
         && dub template "/etc/confluent/docker/tools-log4j.properties.template" "/etc/kafka/tools-log4j.properties" \
-        && kafka-console-consumer --bootstrap-server {brokers} --topic foo --new-consumer --from-beginning --consumer.config /etc/kafka/secrets/{config} --max-messages {messages}"
+        && kafka-console-consumer --bootstrap-server {brokers} --topic foo --from-beginning --consumer.config /etc/kafka/secrets/{config} --max-messages {messages}"
         """
 
 KAFKACAT_SSL_CONSUMER = """kafkacat -X security.protocol=ssl \
@@ -65,7 +65,7 @@ PLAIN_CLIENTS = """bash -c "\
     && kafka-topics --create --topic {topic} --partitions 1 --replication-factor 3 --if-not-exists --zookeeper $KAFKA_ZOOKEEPER_CONNECT \
     && seq {messages} | kafka-console-producer --broker-list {brokers} --topic {topic} \
     && echo PRODUCED {messages} messages. \
-    && kafka-console-consumer --bootstrap-server {brokers} --topic foo --new-consumer --from-beginning --max-messages {messages}"
+    && kafka-console-consumer --bootstrap-server {brokers} --topic foo --from-beginning --max-messages {messages}"
     """
 
 JMX_CHECK = """bash -c "\


### PR DESCRIPTION
It's a no-op in recent versions and it will be
removed in Apache Kafka 2.0.0.