### PR TITLE
Use standard port for kafka brokers : 9092

### DIFF
--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -137,6 +137,8 @@ services:
       - broker
       - connect
       - ksql-server
+    entrypoint: /bin/sh
+    tty: true
 
   ksql-datagen:
     image: confluentinc/ksql-examples:5.0.0-beta30


### PR DESCRIPTION
In the single node cluster use open port as 9092 for kafka brokers which is the standard