### PR TITLE
 switch to multi-stage for kafkacat; bump to 1.3.1

### DIFF
--- a/debian/kafkacat/Dockerfile
+++ b/debian/kafkacat/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:jessie
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
@@ -6,17 +6,30 @@ ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker=true
 
+WORKDIR /build
+ENV VERSION=1.3.0-1
+
+ENV BUILD_PACKAGES="build-essential cmake python git curl zlib1g-dev libsasl2-dev libssl-dev "
 RUN echo "Building kafkacat ....." \
     && apt-get update -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y kafkacat \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y $BUILD_PACKAGES \
+    && git clone https://github.com/edenhill/kafkacat \
+    && cd kafkacat \
+    && git checkout tags/debian/$VERSION \
+    && ./bootstrap.sh \
+    && make install \
+    && cd .. && rm -rf kafkacat-debian-$VERSION \
+    && AUTO_ADDED_PACKAGES=`apt-mark showauto`  \
+    && apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES \
+    \
     && echo "Installing runtime dependencies for SSL and SASL support ...." \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         openssl \
-        libssl1.1 \
+        libssl1.0.0 \
         libsasl2-2 \
         libsasl2-modules-gssapi-mit \
         krb5-user \
         krb5-config \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 CMD ["kafkacat"]

--- a/debian/kafkacat/Dockerfile
+++ b/debian/kafkacat/Dockerfile
@@ -36,6 +36,6 @@ RUN apt-get update -y \
         libsasl2-modules-gssapi-mit \
         krb5-user \
         krb5-config \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 CMD ["kafkacat"]

--- a/debian/kafkacat/Dockerfile
+++ b/debian/kafkacat/Dockerfile
@@ -1,15 +1,11 @@
-FROM debian:jessie
-
-ARG COMMIT_ID=unknown
-LABEL io.confluent.docker.git.id=$COMMIT_ID
-ARG BUILD_NUMBER=-1
-LABEL io.confluent.docker.build.number=$BUILD_NUMBER
-LABEL io.confluent.docker=true
+FROM debian:stretch-slim
 
 WORKDIR /build
-ENV VERSION=1.3.0-1
 
-ENV BUILD_PACKAGES="build-essential cmake python git curl zlib1g-dev libsasl2-dev libssl-dev "
+ENV VERSION=1.3.1-1
+
+ENV BUILD_PACKAGES="build-essential cmake python git curl zlib1g-dev libsasl2-dev libssl-dev"
+
 RUN echo "Building kafkacat ....." \
     && apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y $BUILD_PACKAGES \
@@ -17,15 +13,25 @@ RUN echo "Building kafkacat ....." \
     && cd kafkacat \
     && git checkout tags/debian/$VERSION \
     && ./bootstrap.sh \
-    && make install \
-    && cd .. && rm -rf kafkacat-debian-$VERSION \
-    && AUTO_ADDED_PACKAGES=`apt-mark showauto`  \
-    && apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES \
-    \
+    && make
+
+###
+
+FROM debian:stretch-slim
+
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL io.confluent.docker=true
+
+COPY --from=0 /build/kafkacat/kafkacat /usr/local/bin/
+
+RUN apt-get update -y \
     && echo "Installing runtime dependencies for SSL and SASL support ...." \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         openssl \
-        libssl1.0.0 \
+        libssl1.1 \
         libsasl2-2 \
         libsasl2-modules-gssapi-mit \
         krb5-user \


### PR DESCRIPTION
Installing from debs limited us to available versions in an external apt repo, and the old cleanup routine was nuking important system files. This just copies kafkacat into a mostly-pristine container, and installs runtime deps. Seems cleaner, and seems to work.

Pins the base image to stretch (use the same base as edenhill/kafkacat)