### PR TITLE
Fix kafka-cluster-ssl example

### DIFF
--- a/examples/kafka-cluster-ssl/docker-compose.yml
+++ b/examples/kafka-cluster-ssl/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       KAFKA_SSL_KEY_CREDENTIALS: broker1_sslkey_creds
       KAFKA_SSL_TRUSTSTORE_FILENAME: kafka.broker1.truststore.jks
       KAFKA_SSL_TRUSTSTORE_CREDENTIALS: broker1_truststore_creds
+      KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: " "
+      KAFKA_SSL_CLIENT_AUTH: requested
       KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SSL
     volumes:
       - ${KAFKA_SSL_SECRETS_DIR}:/etc/kafka/secrets
@@ -78,6 +80,8 @@ services:
       KAFKA_SSL_KEY_CREDENTIALS: broker2_sslkey_creds
       KAFKA_SSL_TRUSTSTORE_FILENAME: kafka.broker2.truststore.jks
       KAFKA_SSL_TRUSTSTORE_CREDENTIALS: broker2_truststore_creds
+      KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: " "
+      KAFKA_SSL_CLIENT_AUTH: requested
       KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SSL
     volumes:
       - ${KAFKA_SSL_SECRETS_DIR}:/etc/kafka/secrets
@@ -100,6 +104,8 @@ services:
       KAFKA_SSL_KEY_CREDENTIALS: broker3_sslkey_creds
       KAFKA_SSL_TRUSTSTORE_FILENAME: kafka.broker3.truststore.jks
       KAFKA_SSL_TRUSTSTORE_CREDENTIALS: broker3_truststore_creds
+      KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: " "
+      KAFKA_SSL_CLIENT_AUTH: requested
       KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SSL
     volumes:
       - ${KAFKA_SSL_SECRETS_DIR}:/etc/kafka/secrets

--- a/examples/kafka-cluster-ssl/secrets/host.consumer.ssl.config
+++ b/examples/kafka-cluster-ssl/secrets/host.consumer.ssl.config
@@ -4,6 +4,8 @@ ssl.truststore.password=confluent
 
 ssl.keystore.location=/etc/kafka/secrets/kafka.consumer.keystore.jks
 ssl.keystore.password=confluent
+
 ssl.key.password=confluent
+ssl.endpoint.identification.algorithm= 
 
 security.protocol=SSL

--- a/examples/kafka-cluster-ssl/secrets/host.producer.ssl.config
+++ b/examples/kafka-cluster-ssl/secrets/host.producer.ssl.config
@@ -3,6 +3,8 @@ ssl.truststore.password=confluent
 
 ssl.keystore.location=/etc/kafka/secrets/kafka.producer.keystore.jks
 ssl.keystore.password=confluent
+
 ssl.key.password=confluent
+ssl.endpoint.identification.algorithm= 
 
 security.protocol=SSL


### PR DESCRIPTION
The recent addition of a default value for the `ssl.endpoint.identification.algorithm` has caused things to break; overriding it with a blank value has helped for the most part.

`ssl.client.auth` is set to `requested` since things also break if it isn't. Not familiar with SSL, either in general or with Kafka, so I can't say much more than that. What's certain is that the example doesn't work without that line and it does work with it.