### PR TITLE
[FIX] Confluent Control Center Additional Kafka Cluster Properties

### DIFF
--- a/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/control-center.properties.template
@@ -42,3 +42,8 @@ confluent.metrics.topic.replication={{env.get('CONTROL_CENTER_METRICS_TOPIC_REPL
 {% for name, value in metrics_props.iteritems() -%}
 {{name}}={{value}}
 {% endfor -%}
+
+{% set command_props_additional_cluster = env_to_props('CONTROL_CENTER_CONFLUENT_CONTROLCENTER_KAFKA_', 'confluent.controlcenter.kafka.', exclude=excludes) -%}
+{% for name, value in command_props_additional_cluster.iteritems() -%}
+{{name}}={{value}}
+{% endfor -%}


### PR DESCRIPTION
This pull request resolves the bug described in issue number #543. With this change we add the properties related to the configuration of an additional Kafka cluster to be monitored by Control Center. 

It is tested with a docker-utils repository fork: https://github.com/angelbarrera92/confluent-docker-utils/tree/bugfix/control-center-template

Any questions or suggestions are welcome

Thanks!