### PR TITLE
DOCS-630 - Add Docker-specific titles

### DIFF
--- a/docs/operations/external-volumes.rst
+++ b/docs/operations/external-volumes.rst
@@ -1,7 +1,7 @@
 .. _external_volumes:
 
-Mounting External Volumes
--------------------------
+Mounting Docker External Volumes
+--------------------------------
 
 When working with Docker, you may sometimes need to persist data in the event of a container going down or share data across containers.  In order to do so, you can use `Docker Volumes <https://docs.docker.com/engine/tutorials/dockervolumes/>`_.  In the case of |cp|, we'll need to use external volumes for several main use cases:
 

--- a/docs/operations/logging.rst
+++ b/docs/operations/logging.rst
@@ -1,5 +1,5 @@
-Configuring logging
--------------
+Configuring Docker logging
+--------------------------
 
 All logs are sent to ``stdout`` by default. You can change this by :ref:`extending the images <extending_images>`.
 

--- a/docs/operations/monitoring.rst
+++ b/docs/operations/monitoring.rst
@@ -1,5 +1,5 @@
-Monitoring
----------
+Monitoring Docker
+-----------------
 
 Using JMX
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Added `Docker` to topic titles to improve navigation and SEO in docs.confluent.io