### PR TITLE
Increase timeout for Kafka brokers to be available

### DIFF
--- a/debian/enterprise-control-center/include/etc/confluent/docker/ensure
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/ensure
@@ -22,6 +22,6 @@ set -o nounset \
 echo "===> Check if Kafka is healthy ..."
 
 cub kafka-ready "${CONTROL_CENTER_REPLICATION_FACTOR}" \
-  "${CONTROL_CENTER_CUB_KAFKA_TIMEOUT:-40}" \
+  "${CONTROL_CENTER_CUB_KAFKA_TIMEOUT:-300}" \
   -b "${CONTROL_CENTER_BOOTSTRAP_SERVERS}" \
   --config "${CONTROL_CENTER_CONFIG_DIR}/admin.properties"


### PR DESCRIPTION
At the moment the timeout is 40 seconds, which may well not be long enough for the broker(s) to come up particularly on a machine running the full stack.