### PR TITLE
DEVX-318: build Docker image to include kafka-connect-datagen

### DIFF
--- a/examples/cp-all-in-one/README.md
+++ b/examples/cp-all-in-one/README.md
@@ -2,5 +2,5 @@
 
 # Overview
 
-This `docker-compose.yml` includes all the components of the Confluent Platform to demonstrate how they can be configured to interoperate.
+This `docker-compose.yml` includes all of the Confluent Platform components and shows how you can configure them to interoperate.
 For an example of how to use this Docker setup, refer to the Confluent Platform quickstart: https://docs.confluent.io/current/quickstart/index.html

--- a/examples/cp-all-in-one/README.md
+++ b/examples/cp-all-in-one/README.md
@@ -1,0 +1,6 @@
+![image](../confluent-logo-300-2.png)
+
+# Overview
+
+This `docker-compose.yml` includes all the components of the Confluent Platform to demonstrate how they can be configured to interoperate.
+For an example of how to use this Docker setup, refer to the Confluent Platform quickstart: https://docs.confluent.io/current/quickstart/index.html

--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -74,18 +74,17 @@ services:
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
       CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
-      CONNECT_KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
-      CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
+      CONNECT_KEY_CONVERTER: org.apache.kafka.connect.storage.StringConverter
+      CONNECT_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
       CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       CONNECT_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-5.0.0.jar
       CONNECT_PRODUCER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor"
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
       CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
+      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-5.0.0.jar
 
   control-center:
     image: confluentinc/cp-enterprise-control-center:5.0.0

--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -50,7 +50,7 @@ services:
   connect:
     image: confluentinc/kafka-connect-datagen:0.1.0
     build:
-      context: https://github.com/confluentinc/kafka-connect-datagen/raw/DOCS-941/Dockerfile-confluenthub
+      context: https://github.com/confluentinc/kafka-connect-datagen/raw/master/Dockerfile-confluenthub
       dockerfile: Dockerfile-confluenthub
     hostname: connect
     container_name: connect

--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -48,7 +48,10 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: confluentinc/cp-kafka-connect:5.0.0
+    image: confluentinc/kafka-connect-datagen:0.1.0
+    build:
+      context: https://github.com/confluentinc/kafka-connect-datagen/raw/DOCS-941/Dockerfile-confluenthub
+      dockerfile: Dockerfile-confluenthub
     hostname: connect
     container_name: connect
     depends_on:

--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-5.0.0.jar
       CONNECT_PRODUCER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor"
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
-      CONNECT_PLUGIN_PATH: /usr/share/java
+      CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   control-center:


### PR DESCRIPTION
This updates cp-all-in-one  connect image to have the connector https://www.confluent.io/connector/kafka-connect-datagen/ (to be used by CP quickstart)