### PR TITLE
The conect image specification is incorrect

### DIFF
--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: confluentinc/kafka-connect-datagen:0.1.0
+    image: confluentinc/cp-kafka-connect:5.0.1
     build:
       context: https://github.com/confluentinc/kafka-connect-datagen/raw/master/Dockerfile-confluenthub
       dockerfile: Dockerfile-confluenthub


### PR DESCRIPTION
https://github.com/confluentinc/cp-docker-images/issues/654

docker-compose up -d --build

```
Building connect
Downloading context: https://github.com/confluentinc/kafka-connect-datagen/raw/master/Dockerfile-coStep 1/3 : FROM confluentinc/cp-kafka-connect:5.0.0
 ---> 7df8759460f7
Step 2/3 : ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 ---> Using cache
 ---> bd34aff221da
Step 3/3 : RUN  confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.2.0
 ---> Running in 788129fb0878
Running in a "--no-prompt" mode
Unable to find a component

Error: Component not found, specify either valid name from Confluent Hub in format: <owner>/<name>:<version:latest> or path to a local file
ERROR: Service 'connect' failed to build: The command '/bin/sh -c confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.2.0' returned a non-zero code: 1
```