### PR TITLE
Remove the command,because there were not have the scripts.

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -66,4 +66,3 @@ RUN echo "===> update debian ....." \
 
 COPY include/dub /usr/local/bin/dub
 COPY include/cub /usr/local/bin/cub
-COPY include/etc/confluent/docker /etc/confluent/docker


### PR DESCRIPTION
When I build cp-base image, I got the error with the command. There is no need to copy the folder or the scripts. The `dub` and `cub` instead of them.