### PR TITLE
664: copying monitoring-interceptors jar no longer required since ksq…

### DIFF
--- a/examples/cp-all-in-one/docker-compose.yml
+++ b/examples/cp-all-in-one/docker-compose.yml
@@ -60,8 +60,6 @@ services:
       - schema-registry
     ports:
       - "8083:8083"
-    volumes:
-      - mi2:/usr/share/java/monitoring-interceptors/
     environment:
       CONNECT_BOOTSTRAP_SERVERS: 'broker:9092'
       CONNECT_REST_ADVERTISED_HOST_NAME: connect
@@ -151,15 +149,12 @@ services:
       - broker
       - schema-registry
       - connect
-    volumes:
-      - mi2:/usr/share/java/monitoring-interceptors/
     command: "bash -c 'echo Waiting for Kafka to be ready... && \
                        cub kafka-ready -b broker:9092 1 40 && \
                        echo Waiting for Confluent Schema Registry to be ready... && \
                        cub sr-ready schema-registry 8081 40 && \
                        echo Waiting a few seconds for topic creation to finish... && \
                        sleep 11 && \
-                       cp /usr/share/java/monitoring-interceptors/monitoring-interceptors-5.1.0.jar /usr/share/java/ksql-examples/monitoring-interceptors-5.1.0.jar && \
                        tail -f /dev/null'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"
@@ -183,6 +178,3 @@ services:
       KAFKA_REST_BOOTSTRAP_SERVERS: 'broker:9092'
       KAFKA_REST_LISTENERS: "http://0.0.0.0:8082"
       KAFKA_REST_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
-
-volumes:
-    mi2: {}


### PR DESCRIPTION
…l-examples provides it