### PR TITLE
allow for variable zookeeper server ids

### DIFF
--- a/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
+++ b/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
@@ -38,7 +38,12 @@ dataLogDir=/var/lib/zookeeper/log
 {% if env['ZOOKEEPER_SERVERS'] %}
 {% set servers = env['ZOOKEEPER_SERVERS'].split(';') %}
 {% for server in servers %}
+{% if '|' in server %}
+{% set id, s = server.split('|') %}
+server.{{ id }}={{ s }}
+{% else %}
 server.{{ loop.index }}={{server}}
+{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Hi, this PR allows for optional zookeeper ID's that aren't sequentially based on loop.index.  We needed this functionality because we are generating the ZOOKEEPER_SERVERS environment variable via an Ansible template and need more explicit control over ID's than the loop.index gives us.

The loop.index based pattern is still the default behavior, but if you define your servers in the ZOOKEEPER_SERVERS environment variable with a leading `<id>|`, they'll be templated into the properties file with that id.  For example, specifying:

`ZOOKEEPER_SERVERS=11|zk1:2888:3888;12|zk2:2888:3888;13|zk3:2888:3888`

will result in a properties file containing:

```
server.11=zk1:2888:3888
server.12=zk2:2888:3888
server.13=zk3:2888:3888
```