### PR TITLE
Light changes on punctuation and hyphen usage

### DIFF
--- a/examples/multi-datacenter/README.md
+++ b/examples/multi-datacenter/README.md
@@ -1,9 +1,9 @@
 # Overview
 
-This example deploys an active-active multi-datacenter design, with two instances of Confluent Replicator copying data bi-directionally between the datacenters.
+This example deploys an active-active multi-datacenter design, with two instances of Confluent Replicator copying data bidirectionally between the datacenters.
 This is for demo purposes only, not for production.
 
-Here is a list of Confluent Platform services and their associated ports
+Here is a list of Confluent Platform services and their associated ports:
 
 |                | DC1                     | DC2                     |
 |----------------|-------------------------|-------------------------|
@@ -15,9 +15,9 @@ Here is a list of Confluent Platform services and their associated ports
 # Data generation and topic names
 
 There are also Docker containers with data generators that produce data to the same topic name `topic1` in each datacenter.
-Confluent Replicator 5.0.1 prevents cyclic repetition of data between the DC1 `topic1` and DC2 `topic1`, by using provenance information in the message headers.
+Confluent Replicator 5.0.1 prevents cyclic repetition of data between the DC1 `topic1` and DC2 `topic1` by using provenance information in the message headers.
 
-# Pre-requisites
+# Prerequisites
 
 * Docker version 17.06.1-ce
 * Docker Compose version 1.14.0 with Docker Compose file format 2.1
@@ -36,13 +36,13 @@ Stop all services:
 ./stop.sh
 ```
 
-# Resuming Java Consumer Applications in Failover
+# Resuming Java consumer applications in failover
 
 After a disaster event occurs, consumers can switch datacenters and automatically restart consuming data in the destination cluster where they left off in the origin cluster, a capability introduced in Confluent Platform version 5.0.
 
 To use this capability, configure Java consumer applications with the [Consumer Timestamps Interceptor](https://docs.confluent.io/current/multi-dc-replicator/replicator-failover.html#configuring-the-consumer-for-failover), which is shown in this [sample code](https://github.com/confluentinc/examples/blob/5.0.1-post/clients/avro/src/main/java/io/confluent/examples/clients/basicavro/ConsumerMultiDatacenterExample.java).
 
-1. After starting this Docker environment (see previous section), run the consumer to connect to DC1 Kafka cluster, using the consumer group id `java-consumer-app`.
+1. After starting this Docker environment (see previous section), run the consumer to connect to DC1 Kafka cluster, using the consumer group ID `java-consumer-app`.
 
 ```bash
 git clone https://github.com/confluentinc/examples.git
@@ -83,13 +83,13 @@ You should see some offsets:
 docker-compose stop broker-dc1 schema-registry-dc1
 ```
 
-4. Restart the consumer to connect to DC2 Kafka cluster, still using the same consumer group id `java-consumer-app`:
+4. Restart the consumer to connect to DC2 Kafka cluster, still using the same consumer group ID `java-consumer-app`:
 
 ```bash
 mvn exec:java -Dexec.mainClass=io.confluent.examples.clients.basicavro.ConsumerMultiDatacenterExample -Dexec.args="localhost:29092 http://localhost:8082"
 ```
 
-You should see data sourced from only DC2:
+You should see data sourced only from DC2:
 
 ```bash
 ...
@@ -99,6 +99,6 @@ key = User_5, value = {"userid": "User_5", "dc": "DC2"}
 ...
 ```
 
-# Additional Reading
+# Additional reading
 
-Whitepaper: [Disaster Recovery for Multi-Datacenter Apache Kafka Deployments](https://www.confluent.io/white-paper/disaster-recovery-for-multi-datacenter-apache-kafka-deployments/)
+White paper: [Disaster Recovery for Multi-Datacenter Apache Kafka Deployments](https://www.confluent.io/white-paper/disaster-recovery-for-multi-datacenter-apache-kafka-deployments/)


### PR DESCRIPTION
A few comments in addition to the suggested changes: 1) Should "Consumer Timestamps Interceptor" be capitalized (similar to https://docs.confluent.io/4.0.1/control-center/docs/installation/clients.html)? Features and names of a particular component should be in caps, but we should avoid capitalization where it isn't necessary so just wanted to confirm. 2) From the outside it feels like there should be some article (e.g., the, your) before DC1 in "run the consumer to connect to DC1 Kafka cluster," and same for "connect to DC2 Kafka cluster."