### PR TITLE
Small punctuation changes

### DIFF
--- a/examples/multi-datacenter/README.md
+++ b/examples/multi-datacenter/README.md
@@ -66,23 +66,23 @@ Stop all services:
 
 Monitoring Replicator is important to:
 
-1. gauge how synchronized is the data between multiple datacenters
-2. optimize performance of the network and Confluent Platform
+1. Gauge how synchronized is the data between multiple datacenters
+2. Optimize performance of the network and Confluent Platform
 
 
 ## Multi-datacenter
 
-In this multi-datacenter environment, there are two Kafka clusters `dc1` and `dc2`.
+In this multi-datacenter environment, there are two Kafka clusters, `dc1` and `dc2`.
 Confluent Control Center manages both of these clusters.
-Confluent Replicator is copying data bi-directionally between `dc1` and `dc2`, but for simplicity in explaining how it works, the following sections consider replication only from `dc1` to `dc2`.
+Confluent Replicator is copying data bidirectionally between `dc1` and `dc2`, but for simplicity in explaining how it works, the following sections consider replication only from `dc1` to `dc2`.
 
-1. After starting the demo (see [previous section](#start-the-services), navigate your Chrome browser to the Control Center UI at http://localhost:9021 and verify in the dropdown that there are two Kafka clusters `dc1` and `dc2`:
+1. After starting the demo (see [previous section](#start-the-services), navigate your Chrome browser to the Control Center UI at http://localhost:9021, and verify in the dropdown that there are two Kafka clusters, `dc1` and `dc2`:
 
 ![image](images/c3-two-clusters.png)
 
-2. This demo has two Kafka Connect clusters, `connect-dc1` and `connect-dc2`. Recall that Replicator is a source connector that typically runs on the connect cluster at the destination, so `connect-dc1` runs Replicator copying from `dc2` to `dc1`, and `connect-dc2` runs Replicator copying from `dc1` to `dc2`. At this time, Control Center can manage only one Kafka Connect cluster, and since we are explaining replication only from `dc1` to `dc2`, in this demo Control Center manages the connect workers only in `connect-dc2`.
+2. This demo has two Kafka Connect clusters, `connect-dc1` and `connect-dc2`. Recall that Replicator is a source connector that typically runs on the Connect cluster at the destination, so `connect-dc1` runs Replicator copying from `dc2` to `dc1`, and `connect-dc2` runs Replicator copying from `dc1` to `dc2`. At this time, Control Center can manage only one Kafka Connect cluster, and since we are explaining replication only from `dc1` to `dc2`, in this demo Control Center manages the connect workers only in `connect-dc2`.
 
-3. For Replicator copying from `dc1` to `dc2`: Navigate to http://localhost:9021/management/connect/ to verify that Kafka Connect (configured to `connect-dc2`) is running two instances of Replicator: [replicator-dc1-to-dc2-topic1](submit_replicator_dc1_to_dc2.sh) and [replicator-dc1-to-dc2-topic2](submit_replicator_dc1_to_dc2_topic2.sh).
+3. For Replicator copying from `dc1` to `dc2`, navigate to http://localhost:9021/management/connect/ to verify that Kafka Connect (configured to `connect-dc2`) is running two instances of Replicator: [replicator-dc1-to-dc2-topic1](submit_replicator_dc1_to_dc2.sh) and [replicator-dc1-to-dc2-topic2](submit_replicator_dc1_to_dc2_topic2.sh).
 
 ![image](images/replicator-instances.png)
 
@@ -91,7 +91,7 @@ Confluent Replicator is copying data bi-directionally between `dc1` and `dc2`, b
 Control Center's monitoring capabilities include monitoring stream performance: verifying that all data is consumed and at what throughput and latency.
 Monitoring can be displayed on a per-consumer group or per-topic basis.
 Confluent Replicator has an embedded consumer that reads data from the origin cluster, so you can monitor its performance in Control Center.
-To enable streams monitoring for Replicator, configure it with the Monitoring Consumer Interceptor, as shown in [this example](submit_replicator_dc1_to_dc2.sh).
+To enable streams monitoring for Replicator, configure it with the Monitoring Consumer Interceptor, as shown in this [example](submit_replicator_dc1_to_dc2.sh).
 
 ![image](images/replicator-embedded-consumer.png)
 
@@ -105,8 +105,8 @@ To enable streams monitoring for Replicator, configure it with the Monitoring Co
 
 ## Consumer Lag
 
-Control Center's monitoring capabilities include Consumer Lag, which indicates how many messages behind are consumer groups from the latest offset in the log.
-Replicator has an embedded consumer that reads data from the origin cluster, and it commits its offsets only after the connect worker's producer has committed the data to the destination cluster.
+Control Center's monitoring capabilities include Consumer Lag, which indicates how many messages behind consumer groups are from the latest offset in the log.
+Replicator has an embedded consumer that reads data from the origin cluster, and it commits its offsets only after the Connect worker's producer has committed the data to the destination cluster.
 You can monitor the consumer lag of Replicator's embedded consumer in the origin cluster (for Replicator instances copying data from `dc1` to `dc2`, the origin cluster is `dc1`).
 The ability to monitor Replicator's consumer lag is enabled when it is configured with `offset.topic.commit=true` (`true` by default), which allows Replicator to commit its own consumer offsets to the origin cluster `dc1` after the messages have been written to the destination cluster.
 
@@ -121,11 +121,11 @@ b. Click on `replicator-dc1-to-dc2-topic2` to view Replicator's consumer log in 
 
 ![image](images/c3-consumer-lag-dc1-topic2.png)
 
-6. For Replicator copying from `dc1` to `dc2`: do not mistakingly try to monitor Replicator consumer lag in the destination cluster `dc2`. Control Center also shows the Replicator consumer lag for topics in `dc2` (i.e., `topic1`, `_schemas`, `topic2.replica`) but this does not mean that Replicator is consuming from them. The reason you see this consumer lag in `dc2` is because by default Replicator is configured with `offset.timestamps.commit=true` for which Replicator commits its own offset timestamps of its consumer group in the `__consumer_offsets` topic in the destination cluster `dc2`. In case of disaster recovery, this enables Replicator to resume where it left off when switching to the secondary cluster.
+6. For Replicator copying from `dc1` to `dc2`: Do not mistakingly try to monitor Replicator consumer lag in the destination cluster `dc2`. Control Center also shows the Replicator consumer lag for topics in `dc2` (i.e., `topic1`, `_schemas`, `topic2.replica`) but this does not mean that Replicator is consuming from them. The reason you see this consumer lag in `dc2` is because by default Replicator is configured with `offset.timestamps.commit=true`, for which Replicator commits its own offset timestamps of its consumer group in the `__consumer_offsets` topic in the destination cluster `dc2`. In case of disaster recovery, this enables Replicator to resume where it left off when switching to the secondary cluster.
 
-7. Do not confuse consumer lag with an MBean attribute called `records-lag` associated to Replicator's embedded consumer.
+7. Do not confuse consumer lag with an MBean attribute called `records-lag` associated with Replicator's embedded consumer.
 That attribute reflects whether Replicator's embedded consumer can keep up with the original data production rate, but it does not take into account replication lag producing the messages to the destination cluster.
-`records-lag` is real-time and it is normal for this value to be `0.0`.
+`records-lag` is real time, and it is normal for this value to be `0.0`.
 
 ```bash
 $ docker-compose exec connect-dc2 kafka-run-class kafka.tools.JmxTool --object-name "kafka.consumer:type=consumer-fetch-manager-metrics,partition=0,topic=topic1,client-id=replicator-dc1-to-dc2-topic1-0" --attributes "records-lag" --jmx-url service:jmx:rmi:///jndi/rmi://connect-dc2:9892/jmxrmi
@@ -134,12 +134,12 @@ $ docker-compose exec connect-dc2 kafka-run-class kafka.tools.JmxTool --object-n
 
 # Resume applications after failover
 
-After a disaster event occurs, switch your java consumer application to a different datacenter and then it can automatically restart consuming data in the destination cluster where it left off in the origin cluster.
+After a disaster event occurs, switch your Java consumer application to a different datacenter, and then it can automatically restart consuming data in the destination cluster where it left off in the origin cluster.
 
 To use this capability, configure Java consumer applications with the [Consumer Timestamps Interceptor](https://docs.confluent.io/current/multi-dc-replicator/replicator-failover.html#configuring-the-consumer-for-failover), which is shown in this [sample code](src/main/java/io/confluent/examples/clients/ConsumerMultiDatacenterExample.java).
 
 
-1. After starting this Docker environment (see [previous section](#start-the-services), run the consumer to connect to dc1 Kafka cluster. It automatically configures the consumer group ID as `java-consumer-topic1` and uses the Consumer Timestamps Interceptor and Monitoring Interceptor.
+1. After starting this Docker environment (see [previous section](#start-the-services), run the consumer to connect to the dc1 Kafka cluster. It automatically configures the consumer group ID as `java-consumer-topic1` and uses the Consumer Timestamps Interceptor and Monitoring Interceptor.
 
 ```bash
 mvn clean package
@@ -178,7 +178,7 @@ Verify that there are committed offsets:
 $ docker-compose stop connect-dc1 schema-registry-dc1 broker-dc1 zookeeper-dc1
 ```
 
-4. Stop and restart the consumer to connect to `dc2` Kafka cluster. It will still use the same consumer group ID `java-consumer-topic1` so it can resume where it left off:
+4. Stop and restart the consumer to connect to the `dc2` Kafka cluster. It will still use the same consumer group ID `java-consumer-topic1` so it can resume where it left off:
 
 ```bash
 mvn exec:java -Dexec.mainClass=io.confluent.examples.clients.ConsumerMultiDatacenterExample -Dexec.args="topic1 localhost:29092 http://localhost:8082 localhost:29092"
@@ -196,4 +196,4 @@ key = User_5, value = {"userid": "User_5", "dc": "dc2"}
 
 # Additional reading
 
-* For a practical guide to designing and configuring multiple Apache Kafka clusters to be resilient in case of a disaster scenario, see the `Disaster Recovery <https://www.confluent.io/white-paper/disaster-recovery-for-multi-datacenter-apache-kafka-deployments/>`_ white paper. This white paper provides a plan for failover, failback, and ultimately successful recovery.
+* For a practical guide to designing and configuring multiple Apache Kafka clusters to be resilient in case of a disaster scenario, see the [Disaster Recovery white paper](https://www.confluent.io/white-paper/disaster-recovery-for-multi-datacenter-apache-kafka-deployments/). This white paper provides a plan for failover, failback and ultimately successful recovery.

--- a/examples/multi-datacenter/README.md
+++ b/examples/multi-datacenter/README.md
@@ -72,7 +72,7 @@ Monitoring Replicator is important to:
 
 ## Multi-datacenter
 
-In this multi-datacenter environment, there are two Kafka clusters, `dc1` and `dc2`.
+In this multi-datacenter environment, there are two Apache Kafka<sup>®</sup> clusters, `dc1` and `dc2`.
 Confluent Control Center manages both of these clusters.
 Confluent Replicator is copying data bidirectionally between `dc1` and `dc2`, but for simplicity in explaining how it works, the following sections consider replication only from `dc1` to `dc2`.
 


### PR DESCRIPTION
I'm not sure if "consumer lag" should be capitalized. It looks like something we monitor but in it of itself isn't a capability or formal name for it. Also, regarding the sentence, "...`replicator-dc1-to-dc2-topic2` to view Replicator's consumer log," should it actually be "lag"?