### PR TITLE
cp-kafkacat: add ca-certificates

### DIFF
--- a/debian/kafkacat/Dockerfile
+++ b/debian/kafkacat/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update -y \
         libsasl2-modules-gssapi-mit \
         krb5-user \
         krb5-config \
+        ca-certificates \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 CMD ["kafkacat"]


### PR DESCRIPTION
Root CA certs are required to connect to ccloud.