### PR TITLE
Bug fix kafka mqtt confluent topic replication factor

### DIFF
--- a/examples/kafka-mqtt-single-node/docker-compose.yml
+++ b/examples/kafka-mqtt-single-node/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - kafka
     environment:
       KAFKA_MQTT_BOOTSTRAP_SERVERS: PLAINTEXT://localhost:29092
+      KAFKA_MQTT_CONFLUENT_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_MQTT_TOPIC_REGEX_LIST: temperature:.*
     extra_hosts:
       - "moby:127.0.0.1"


### PR DESCRIPTION
The Kafka MQTT single node example is missing an environment variable: `KAFKA_MQTT_CONFLUENT_TOPIC_REPLICATION_FACTOR: 1`

This is causing the following error:
```plain
kafka-mqtt_1  | [2019-03-19 11:21:42,641] [main] ERROR Stopping Kafka-MQTT due to error (io.confluent.mqtt.KafkaMqttMain:68)
kafka-mqtt_1  | org.apache.kafka.connect.errors.ConnectException: Error while attempting to create/find topic(s) '_confluent-command'
kafka-mqtt_1  | 	at org.apache.kafka.connect.util.TopicAdmin.createTopics(TopicAdmin.java:255)
kafka-mqtt_1  | 	at io.confluent.license.LicenseStore$1.run(LicenseStore.java:161)
kafka-mqtt_1  | 	at org.apache.kafka.connect.util.KafkaBasedLog.start(KafkaBasedLog.java:127)
kafka-mqtt_1  | 	at io.confluent.license.LicenseStore.start(LicenseStore.java:190)
kafka-mqtt_1  | 	at io.confluent.license.LicenseManager.<init>(LicenseManager.java:155)
kafka-mqtt_1  | 	at io.confluent.license.LicenseManager.<init>(LicenseManager.java:140)
kafka-mqtt_1  | 	at io.confluent.mqtt.KafkaMqttMain.checkLicense(KafkaMqttMain.java:91)
kafka-mqtt_1  | 	at io.confluent.mqtt.KafkaMqttMain.main(KafkaMqttMain.java:45)
kafka-mqtt_1  | Caused by: java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.InvalidReplicationFactorException: Replication factor: 3 larger than available brokers: 1.
kafka-mqtt_1  | 	at org.apache.kafka.common.internals.KafkaFutureImpl.wrapAndThrow(KafkaFutureImpl.java:45)
kafka-mqtt_1  | 	at org.apache.kafka.common.internals.KafkaFutureImpl.access$000(KafkaFutureImpl.java:32)
kafka-mqtt_1  | 	at org.apache.kafka.common.internals.KafkaFutureImpl$SingleWaiter.await(KafkaFutureImpl.java:89)
kafka-mqtt_1  | 	at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:262)
kafka-mqtt_1  | 	at org.apache.kafka.connect.util.TopicAdmin.createTopics(TopicAdmin.java:228)
kafka-mqtt_1  | 	... 7 more
kafka-mqtt_1  | Caused by: org.apache.kafka.common.errors.InvalidReplicationFactorException: Replication factor: 3 larger than available brokers: 1.
kafka-mqtt-single-node_kafka-mqtt_1 exited with code 2
```

The environment variable is present in `kafka-mqtt-single-node-ssl-producer` example.