### PR TITLE
Remove *BASIC_AUTH_USER_INFO fields from show_env

### DIFF
--- a/debian/base/include/etc/confluent/docker/bash-config
+++ b/debian/base/include/etc/confluent/docker/bash-config
@@ -24,5 +24,5 @@ fi
 
 
 function show_env {
-    env | sort | grep -vP 'PASSWORD|JAAS_CONFIG'
+    env | sort | grep -vP 'PASSWORD|JAAS_CONFIG|BASIC_AUTH_USER_INFO'
 }


### PR DESCRIPTION
We don't want to log any sensitive data on startup, so I would like to exclude all of the BASIC_AUTH_USER_INFO fields from the `show_env` function. This will make sure that no sensitive data gets logged and sent to any shared logging systems.