### PR TITLE
Debian has removed mirrors for jessie, switch to archives

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -51,6 +51,9 @@ ENV ZULU_OPENJDK_VERSION="8=8.17.0.3"
 ENV LANG="C.UTF-8"
 
 RUN echo "===> Updating debian ....." \
+    # TODO debian jessie has been deprecated and is only ex
+    && echo "deb http://archive.debian.org/debian/ jessie main" > /etc/apt/sources.list \
+    && echo "deb http://security.debian.org jessie/updates main" >> /etc/apt/sources.list \
     && apt-get -qq update \
     \
     && echo "===> Installing curl wget netcat python...." \


### PR DESCRIPTION
We will migrate from jessie to stretch most likely.

https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html