### PR TITLE
secure defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COMMIT_ID := $(shell git rev-parse --short HEAD)
 MYSQL_DRIVER_VERSION := 5.1.39
 
 # Set this variable externally to point at a different repo, such as when building SNAPSHOT images
-CONFLUENT_PACKAGES_REPO ?= http://packages.confluent.io
+CONFLUENT_PACKAGES_REPO ?= https://packages.confluent.io
 
 # Set to false for public releases
 ALLOW_UNSIGNED ?= false

--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -72,6 +72,7 @@ RUN echo "===> Updating debian ....." \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 apt-transport-https \
                 curl \
+                gnupg-curl \
                 git \
                 wget \
                 netcat \
@@ -82,7 +83,7 @@ RUN echo "===> Updating debian ....." \
     && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 \
+    && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \
     && echo "deb http://repos.azulsystems.com/debian stable  main" >> /etc/apt/sources.list.d/zulu.list \
     && apt-get -qq update \
     && apt-get -y install zulu-${ZULU_OPENJDK_VERSION} \


### PR DESCRIPTION
* fetch gpg keys from secure endpoint using full fingerprint
* use secure Confluent repo by default