### PR TITLE
MINOR: Depend on checkstyle version from common pom

### DIFF
--- a/examples/multi-datacenter/pom.xml
+++ b/examples/multi-datacenter/pom.xml
@@ -105,13 +105,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>8.12</version> <!-- bumping to latest checkstyle version -->
-                    </dependency>
-                </dependencies>
                 <executions>
                     <!--
                      This declaration merges with the one in the parent, rather


### PR DESCRIPTION
The common repo is now on a newer version and this is easier to manage centrally in one place unless we have a specific need to override in specific repos.