### PR TITLE
fix parameter names

### DIFF
--- a/debian/kafka-rest/include/etc/confluent/docker/configure
+++ b/debian/kafka-rest/include/etc/confluent/docker/configure
@@ -30,9 +30,9 @@ then
   exit 1
 fi
 
-if [[ -n "${KAFKA_REST_JMX_OPTS-}" ]]
+if [[ -n "${KAFKAREST_JMX_OPTS-}" ]]
 then
-  if [[ ! $KAFKA_REST_JMX_OPTS == *"com.sun.management.jmxremote.rmi.port"*  ]]
+  if [[ ! $KAFKAREST_JMX_OPTS == *"com.sun.management.jmxremote.rmi.port"*  ]]
   then
     echo "KAFKA_REST_OPTS should contain 'com.sun.management.jmxremote.rmi.port' property. It is required for accessing the JMX metrics externally."
   fi

--- a/debian/kafka-rest/include/etc/confluent/docker/launch
+++ b/debian/kafka-rest/include/etc/confluent/docker/launch
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # JMX settings
-if [ -z "$KAFKA_REST_JMX_OPTS" ]; then
-  KAFKA_REST_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
+if [ -z "$KAFKAREST_JMX_OPTS" ]; then
+  KAFKAREST_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
 fi
 
 # The JMX client needs to be able to connect to java.rmi.server.hostname.
@@ -26,11 +26,11 @@ fi
 # If you have more that one n/w configured, hostname -i gives you all the IPs,
 # the default is to pick the first IP (or network).
 export KAFKA_REST_JMX_HOSTNAME=${KAFKA_REST_JMX_HOSTNAME:-$(hostname -i | cut -d" " -f1)}
-
+z
 # JMX port to use
-if [  $KAFKA_REST_JMX_PORT ]; then
-  export JMX_PORT=$KAFKA_REST_JMX_PORT
-export KAFKA_REST_JMX_OPTS="$KAFKA_REST_JMX_OPTS -Djava.rmi.server.hostname=$KAFKA_REST_JMX_HOSTNAME -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT -Dcom.sun.management.jmxremote.port=$JMX_PORT"
+if [  $KAFKAREST_JMX_PORT ]; then
+  export JMX_PORT=$KAFKAREST_JMX_PORT
+export KAFKAREST_JMX_OPTS="$KAFKAREST_JMX_OPTS -Djava.rmi.server.hostname=$KAFKA_REST_JMX_HOSTNAME -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT -Dcom.sun.management.jmxremote.port=$JMX_PORT"
 fi
 
 echo "===> Launching ${COMPONENT} ... "

--- a/debian/kafka-rest/include/etc/confluent/docker/launch
+++ b/debian/kafka-rest/include/etc/confluent/docker/launch
@@ -26,7 +26,7 @@ fi
 # If you have more that one n/w configured, hostname -i gives you all the IPs,
 # the default is to pick the first IP (or network).
 export KAFKA_REST_JMX_HOSTNAME=${KAFKA_REST_JMX_HOSTNAME:-$(hostname -i | cut -d" " -f1)}
-z
+
 # JMX port to use
 if [  $KAFKAREST_JMX_PORT ]; then
   export JMX_PORT=$KAFKAREST_JMX_PORT

--- a/tests/fixtures/debian/kafka-rest/standalone-network.yml
+++ b/tests/fixtures/debian/kafka-rest/standalone-network.yml
@@ -77,7 +77,7 @@ services:
       - zk
     environment:
       KAFKA_REST_ZOOKEEPER_CONNECT: zookeeper-bridge:2181
-      KAFKA_REST_JMX_PORT: 9999
+      KAFKAREST_JMX_PORT: 9999
       KAFKA_REST_HOST_NAME: kafka-rest-bridged-jmx
     labels:
     - io.confluent.docker.testing=true
@@ -87,7 +87,7 @@ services:
     network_mode: host
     environment:
       KAFKA_REST_ZOOKEEPER_CONNECT: localhost:32181
-      KAFKA_REST_JMX_PORT: 39999
+      KAFKAREST_JMX_PORT: 39999
       KAFKA_REST_LISTENERS: "http://0.0.0.0:28082"
       KAFKA_REST_HOST_NAME: localhost
     labels:


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/ST-1584

>In the launch script, the variable KAFKA_REST_JMX_PORT is being set. However, within /usr/bin/kafka-rest-run-class inside the container, that variable is never being used. Instead, the variable is KAFKAREST_JMX_OPTS. Because of this mismatch in variable names, the RMI and JMX Hostname parameters are never set.


There is a name issue between `cp-docker-images` and `kafka-rest`. After considering the compatbility, I decide to change `cp-docker-images`. From `KAFKA_REST_JMX_OPTS ` and `KAFKA_REST_JMX_PORT ` to `KAFKAREST_JMX_OPTS ` and `KAFKAREST_JMX_PORT `.

Since we still support 3.3.x, so I made the changes from 3.3.x.

In future, we may still need to consider the name conventions.