### PR TITLE
CC-5432: Add Confluent security plugins to Connect Docker image

### DIFF
--- a/debian/kafka-connect-base/Dockerfile
+++ b/debian/kafka-connect-base/Dockerfile
@@ -35,6 +35,8 @@ RUN echo "===> Installing Schema Registry (for Avro jars) ..." \
         confluent-schema-registry=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..."\
     && apt-get install -y confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Installing Confluent security plugins ..."\
+    && apt-get install -y confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Installing Confluent Hub client ..."\
     && apt-get install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CC-5432)

We need to include the `confluent-security` package in our Docker image for Connect in order to support RBAC.