### PR TITLE
CC-5454, CC-5456: Add new cp-server-connect-base and cp-server-connect images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONFLUENT_VERSION ?= ${CONFLUENT_MAJOR_VERSION}.${CONFLUENT_MINOR_VERSION}.${CON
 
 KAFKA_VERSION ?= 2.3.0
 
-COMPONENTS := base zookeeper kafka server kafka-rest schema-registry kafka-connect-base kafka-connect enterprise-control-center kafkacat enterprise-replicator enterprise-replicator-executable enterprise-kafka kafka-mqtt
+COMPONENTS := base zookeeper kafka server kafka-rest schema-registry kafka-connect-base kafka-connect server-connect-base server-connect enterprise-control-center kafkacat enterprise-replicator enterprise-replicator-executable enterprise-kafka kafka-mqtt
 COMMIT_ID := $(shell git rev-parse --short HEAD)
 MYSQL_DRIVER_VERSION := 5.1.39
 

--- a/debian/enterprise-replicator/Dockerfile
+++ b/debian/enterprise-replicator/Dockerfile
@@ -15,7 +15,7 @@
 
 # Builds a docker image for Replicator
 
-FROM confluentinc/cp-kafka-connect-base
+FROM confluentinc/cp-server-connect-base
 
 MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true

--- a/debian/kafka-connect-base/Dockerfile
+++ b/debian/kafka-connect-base/Dockerfile
@@ -35,8 +35,6 @@ RUN echo "===> Installing Schema Registry (for Avro jars) ..." \
         confluent-schema-registry=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..."\
     && apt-get install -y confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> Installing Confluent security plugins ..."\
-    && apt-get install -y confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Installing Confluent Hub client ..."\
     && apt-get install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \

--- a/debian/server-connect-base/Dockerfile
+++ b/debian/server-connect-base/Dockerfile
@@ -1,0 +1,52 @@
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds a docker image for Kafka Connect
+
+FROM confluentinc/cp-server
+
+MAINTAINER partner-support@confluent.io
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ENV COMPONENT=kafka-connect
+
+# Default kafka-connect rest.port
+EXPOSE 8083
+
+RUN echo "===> Installing Schema Registry (for Avro jars) ..." \
+    && apt-get -qq update \
+    && apt-get install -y \
+        confluent-schema-registry=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Installing Controlcenter for monitoring interceptors ..."\
+    && apt-get install -y confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Installing Confluent security plugins ..."\
+    && apt-get install -y confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Installing Confluent Hub client ..."\
+    && apt-get install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
+    echo "===> Setting up ${COMPONENT} dirs ..." \
+    && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
+    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
+
+VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]

--- a/debian/server-connect-base/Dockerfile
+++ b/debian/server-connect-base/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 Confluent Inc.
+# Copyright 2019 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/debian/server-connect-base/include/etc/confluent/docker/apply-mesos-overrides
+++ b/debian/server-connect-base/include/etc/confluent/docker/apply-mesos-overrides
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mesos DC/OS docker deployments will have HOST and PORT0 
+# set for the proxying of the service.
+# 
+# Use those values provide things we know we'll need.
+
+[ -n "${HOST:-}" ] && [ -z "${CONNECT_REST_ADVERTISED_HOST_NAME:-}" ] && \
+	export CONNECT_REST_ADVERTISED_HOST_NAME=$HOST || true
+
+[ -n "${PORT0:-}" ] && [ -z "${CONNECT_REST_ADVERTISED_PORT:-}" ] && \
+	export CONNECT_REST_ADVERTISED_PORT=$PORT0 || true
+
+# And default to 8083, which MUST match the containerPort specification
+# in the Mesos package for this service.
+[ -z "${CONNECT_REST_PORT:-}" ] && \
+	export CONNECT_REST_PORT=8083 || true
+

--- a/debian/server-connect-base/include/etc/confluent/docker/apply-mesos-overrides
+++ b/debian/server-connect-base/include/etc/confluent/docker/apply-mesos-overrides
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016 Confluent Inc.
+# Copyright 2019 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/debian/server-connect-base/include/etc/confluent/docker/configure
+++ b/debian/server-connect-base/include/etc/confluent/docker/configure
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. /etc/confluent/docker/bash-config
+
+dub ensure CONNECT_BOOTSTRAP_SERVERS
+dub ensure CONNECT_GROUP_ID
+dub ensure CONNECT_CONFIG_STORAGE_TOPIC
+dub ensure CONNECT_OFFSET_STORAGE_TOPIC
+dub ensure CONNECT_STATUS_STORAGE_TOPIC
+dub ensure CONNECT_KEY_CONVERTER
+dub ensure CONNECT_VALUE_CONVERTER
+dub ensure CONNECT_INTERNAL_KEY_CONVERTER
+dub ensure CONNECT_INTERNAL_VALUE_CONVERTER
+# This is required to avoid config bugs. You should set this to a value that is
+# resolvable by all containers.
+dub ensure CONNECT_REST_ADVERTISED_HOST_NAME
+
+# Default to 8083, which matches the mesos-overrides. This is here in case we extend the containers to remove the mesos overrides.
+if [ -z "$CONNECT_REST_PORT" ]; then
+  export CONNECT_REST_PORT=8083
+fi
+
+# Fix for https://issues.apache.org/jira/browse/KAFKA-3988
+if [[ $CONNECT_INTERNAL_KEY_CONVERTER == "org.apache.kafka.connect.json.JsonConverter" ]] || [[ $CONNECT_INTERNAL_VALUE_CONVERTER == "org.apache.kafka.connect.json.JsonConverter" ]]
+then
+  export CONNECT_INTERNAL_KEY_CONVERTER_SCHEMAS_ENABLE=false
+  export CONNECT_INTERNAL_VALUE_CONVERTER_SCHEMAS_ENABLE=false
+fi
+
+if [[ $CONNECT_KEY_CONVERTER == "io.confluent.connect.avro.AvroConverter" ]]
+then
+  dub ensure CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
+fi
+
+if [[ $CONNECT_VALUE_CONVERTER == "io.confluent.connect.avro.AvroConverter" ]]
+then
+  dub ensure CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL
+fi
+
+dub path /etc/"${COMPONENT}"/ writable
+
+dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "/etc/${COMPONENT}/${COMPONENT}.properties"
+
+# The connect-distributed script expects the log4j config at /etc/kafka/connect-log4j.properties.
+dub template "/etc/confluent/docker/log4j.properties.template" "/etc/kafka/connect-log4j.properties"

--- a/debian/server-connect-base/include/etc/confluent/docker/configure
+++ b/debian/server-connect-base/include/etc/confluent/docker/configure
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016 Confluent Inc.
+# Copyright 2019 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/debian/server-connect-base/include/etc/confluent/docker/ensure
+++ b/debian/server-connect-base/include/etc/confluent/docker/ensure
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. /etc/confluent/docker/bash-config
+
+echo "===> Check if Kafka is healthy ..."
+
+if [[ -n "${CONNECT_SECURITY_PROTOCOL-}" ]] && [[ $CONNECT_SECURITY_PROTOCOL != "PLAINTEXT" ]]
+then
+
+    cub kafka-ready \
+        "${CONNECT_CUB_KAFKA_MIN_BROKERS:-1}" \
+        "${CONNECT_CUB_KAFKA_TIMEOUT:-40}" \
+        -b "$CONNECT_BOOTSTRAP_SERVERS" \
+        --config /etc/"${COMPONENT}"/kafka-connect.properties
+else
+
+    cub kafka-ready \
+        "${CONNECT_CUB_KAFKA_MIN_BROKERS:-1}" \
+        "${CONNECT_CUB_KAFKA_TIMEOUT:-40}" \
+        -b "$CONNECT_BOOTSTRAP_SERVERS"
+fi

--- a/debian/server-connect-base/include/etc/confluent/docker/ensure
+++ b/debian/server-connect-base/include/etc/confluent/docker/ensure
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016 Confluent Inc.
+# Copyright 2019 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/debian/server-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
+++ b/debian/server-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
@@ -1,0 +1,4 @@
+{% set connect_props = env_to_props('CONNECT_', '') -%}
+{% for name, value in connect_props.iteritems() -%}
+{{name}}={{value}}
+{% endfor -%}

--- a/debian/server-connect-base/include/etc/confluent/docker/launch
+++ b/debian/server-connect-base/include/etc/confluent/docker/launch
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Override this section from the script to include the com.sun.management.jmxremote.rmi.port property.
+if [ -z "$KAFKA_JMX_OPTS" ]; then
+  export KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false  -Dcom.sun.management.jmxremote.ssl=false "
+fi
+
+# The JMX client needs to be able to connect to java.rmi.server.hostname.
+# The default for bridged n/w is the bridged IP so you will only be able to connect from another docker container.
+# For host n/w, this is the IP that the hostname on the host resolves to.
+
+# If you have more that one n/w configured, hostname -i gives you all the IPs,
+# the default is to pick the first IP (or network).
+export KAFKA_JMX_HOSTNAME=${KAFKA_JMX_HOSTNAME:-$(hostname -i | cut -d" " -f1)}
+
+if [ "$KAFKA_JMX_PORT" ]; then
+  # This ensures that the "if" section for JMX_PORT in kafka launch script does not trigger.
+  export JMX_PORT=$KAFKA_JMX_PORT
+  export KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Djava.rmi.server.hostname=$KAFKA_JMX_HOSTNAME -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT -Dcom.sun.management.jmxremote.port=$JMX_PORT"
+fi
+
+echo "===> Launching ${COMPONENT} ... "
+# Add external jars to the classpath
+# And this also makes sure that the CLASSPATH does not start with ":/etc/..."
+# because this causes the plugin scanner to scan the entire disk.
+export CLASSPATH="/etc/kafka-connect/jars/*"
+exec connect-distributed /etc/"${COMPONENT}"/"${COMPONENT}".properties

--- a/debian/server-connect-base/include/etc/confluent/docker/launch
+++ b/debian/server-connect-base/include/etc/confluent/docker/launch
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016 Confluent Inc.
+# Copyright 2019 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/debian/server-connect-base/include/etc/confluent/docker/log4j.properties.template
+++ b/debian/server-connect-base/include/etc/confluent/docker/log4j.properties.template
@@ -1,0 +1,23 @@
+
+log4j.rootLogger={{ env["CONNECT_LOG4J_ROOT_LOGLEVEL"] | default('INFO') }}, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+{% set default_loggers = {
+	'org.reflections': 'ERROR',
+	'org.apache.zookeeper': 'ERROR',
+	'org.I0Itec.zkclient': 'ERROR'
+} -%}
+
+{% if env['CONNECT_LOG4J_LOGGERS'] %}
+# loggers from CONNECT_LOG4J_LOGGERS env variable
+{% set loggers = parse_log4j_loggers(env['CONNECT_LOG4J_LOGGERS']) %}
+{% else %}
+# default log levels
+{% set loggers = default_loggers %}
+{% endif %}
+{% for logger,loglevel in loggers.iteritems() %}
+log4j.logger.{{logger}}={{loglevel}}
+{% endfor %}

--- a/debian/server-connect-base/include/etc/confluent/docker/run
+++ b/debian/server-connect-base/include/etc/confluent/docker/run
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. /etc/confluent/docker/bash-config
+
+. /etc/confluent/docker/mesos-setup.sh
+. /etc/confluent/docker/apply-mesos-overrides
+
+echo "===> ENV Variables ..."
+show_env
+
+echo "===> User"
+id
+
+echo "===> Configuring ..."
+/etc/confluent/docker/configure
+
+echo "===> Running preflight checks ... "
+/etc/confluent/docker/ensure
+
+echo "===> Launching ... "
+exec /etc/confluent/docker/launch

--- a/debian/server-connect-base/include/etc/confluent/docker/run
+++ b/debian/server-connect-base/include/etc/confluent/docker/run
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016 Confluent Inc.
+# Copyright 2019 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/debian/server-connect/Dockerfile
+++ b/debian/server-connect/Dockerfile
@@ -1,0 +1,41 @@
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds a docker image for Kafka Connect
+
+FROM confluentinc/cp-server-connect-base
+
+MAINTAINER partner-support@confluent.io
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ENV COMPONENT=kafka-connect
+
+RUN echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
+    && apt-get -qq update \
+    && apt-get install -y \
+        confluent-kafka-connect-jdbc=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+        confluent-kafka-connect-elasticsearch=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+        confluent-kafka-connect-storage-common=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+        confluent-kafka-connect-s3=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+        confluent-kafka-connect-jms=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*
+
+RUN echo "===> Installing GCS Sink Connector ..."
+RUN confluent-hub install confluentinc/kafka-connect-gcs:latest --no-prompt

--- a/debian/server-connect/Dockerfile
+++ b/debian/server-connect/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 Confluent Inc.
+# Copyright 2019 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
[CC-5454](https://confluentinc.atlassian.net/browse/CC-5454) covers how we plan to add two new enterprise Connect images that derive from `cp-server` instead of `cp-kafka`, and revert the recent changes for CC-5432 which added the `confluent-security` package to the `cp-kafka-connect-base` image.
[CC-5456](https://confluentinc.atlassian.net/browse/CC-5456) covers how we should alter our Replicator images to derive from `cp-server` instead of `cp-kafka` as well.

The changes here address both issues. Two new images, `cp-server-connect-base`, and `cp-server-connect`, are added; they mirror the existing `cp-kafka-connect-base` and `cp-kafka-connect` images and the only difference is that `cp-server-connect-base` inherits from `cp-server` instead of `cp-kafka`, `cp-server-connect` inherits from `cp-server-connect-base` instead of `cp-kafka-connect-base`, and `cp-server-connect-base` includes the `confluent-security` package. The Replicator image is altered to inherit from this new `cp-server-connect-base` image instead of the `cp-kafka-connect-base` image. Because the Replicator Executable image inherits from the regular Replicator image, it too is transitively affected, though it isn't explicitly changed in this PR.

**NOTE FOR REVIEWERS**: Don't be fooled by the size of this PR; a recursive diff between `debian/kafka-connect-base` and `debian/server-connect-base`, and between `debian/kafka-connect` and `debian/server-connect`, clearly demonstrates that the new images are near-identical copies of existing ones and the actual changes are very small. Because this PR is a release blocker, please refrain from reviewing the unchanged parts of the new images that come directly from the existing images unless there is either a bug in both or some new difference between the two is warranted.

Both new images have been tested manually and verified. Automated Python tests have not yet been added for them; if those are deemed important enough to be release blockers, I can add them to this PR as well.