### PR TITLE
Add packages for building paramiko

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -77,6 +77,7 @@ RUN echo "===> Updating debian ....." \
                 wget \
                 netcat \
                 python=${PYTHON_VERSION} \
+                build-essential libssl-dev libffi-dev python-dev \
     && echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \


### PR DESCRIPTION
/usr/local/bin/dup needs the paramiko that needs build-essential libssl-dev libffi-dev python-dev.