### PR TITLE
Add healthcheck for Kafka Connect

### DIFF
--- a/debian/kafka-connect-base/Dockerfile
+++ b/debian/kafka-connect-base/Dockerfile
@@ -54,5 +54,5 @@ CMD ["/etc/confluent/docker/run"]
 # Start-up period : 2 minutes (during which failures are not counted as failures)
 # Retry period    : 8 minutes (after which container is deemed unhealthy)
 # All settings can be overriden at run-time in Docker/Docker Compose. 
-HEALTHCHECK --start-period 120s --interval=5s --timeout=10s --retries=96 \
+HEALTHCHECK --start-period=120s --interval=5s --timeout=10s --retries=96 \
 	CMD /etc/confluent/docker/healthcheck.sh

--- a/debian/kafka-connect-base/Dockerfile
+++ b/debian/kafka-connect-base/Dockerfile
@@ -48,3 +48,6 @@ VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
 COPY include/etc/confluent/docker /etc/confluent/docker
 
 CMD ["/etc/confluent/docker/run"]
+
+HEALTHCHECK --interval=5s --timeout=10s --retries=120 \
+	CMD /etc/ksql-server/healthcheck.sh 

--- a/debian/kafka-connect-base/Dockerfile
+++ b/debian/kafka-connect-base/Dockerfile
@@ -50,4 +50,4 @@ COPY include/etc/confluent/docker /etc/confluent/docker
 CMD ["/etc/confluent/docker/run"]
 
 HEALTHCHECK --interval=5s --timeout=10s --retries=120 \
-	CMD /etc/ksql-server/healthcheck.sh 
+	CMD /etc/confluent/docker/healthcheck.sh

--- a/debian/kafka-connect-base/Dockerfile
+++ b/debian/kafka-connect-base/Dockerfile
@@ -49,5 +49,10 @@ COPY include/etc/confluent/docker /etc/confluent/docker
 
 CMD ["/etc/confluent/docker/run"]
 
-HEALTHCHECK --interval=5s --timeout=10s --retries=120 \
+# Polling period  : 5 seconds
+# Timeout period  :10 seconds (if the polling does not return within this time, treat as a failed poll)
+# Start-up period : 2 minutes (during which failures are not counted as failures)
+# Retry period    : 8 minutes (after which container is deemed unhealthy)
+# All settings can be overriden at run-time in Docker/Docker Compose. 
+HEALTHCHECK --start-period 120s --interval=5s --timeout=10s --retries=96 \
 	CMD /etc/confluent/docker/healthcheck.sh

--- a/debian/kafka-connect-base/include/etc/confluent/docker/healthcheck.sh
+++ b/debian/kafka-connect-base/include/etc/confluent/docker/healthcheck.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [[ -z $CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM ]]; then
+  if [[ $(curl -s -o /dev/null -w %{http_code} http://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/) = 200 ]]; then
+    echo "Woohoo! Kafka Connect is up!"
+    exit 0
+  else 
+    echo -e $(date) "\tKafka Connect HTTP state: " $(curl -s -o /dev/null -w %{http_code} $CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/info) " (waiting for 200)"
+    exit 1
+  fi
+else
+  if [[ $(curl -k -s -o /dev/null -w %{http_code} $CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/) = 200 ]]; then
+    echo "Woohoo! Kafka Connect with SSL listener is up!"
+    exit 0
+  else 
+    echo -e $(date) "\tKafka Connect with SSL listener HTTP state: " $(curl -k -s -o /dev/null -w %{http_code} http://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/info) " (waiting for 200)"
+    exit 1
+  fi
+fi

--- a/debian/kafka-connect-base/include/etc/confluent/docker/healthcheck.sh
+++ b/debian/kafka-connect-base/include/etc/confluent/docker/healthcheck.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
 if [[ -z $CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM ]]; then
-  if [[ $(curl -s -o /dev/null -w %{http_code} http://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/) = 200 ]]; then
+  if [[ $(curl -s -o /dev/null -w %{http_code} http://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/connectors) = 200 ]]; then
     echo "Woohoo! Kafka Connect is up!"
     exit 0
   else 
-    echo -e $(date) "\tKafka Connect HTTP state: " $(curl -s -o /dev/null -w %{http_code} $CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/) " (waiting for 200)"
+    echo -e $(date) "\tKafka Connect HTTP state: " $(curl -s -o /dev/null -w %{http_code} $CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/connectors) " (waiting for 200)"
     exit 1
   fi
 else
-  if [[ $(curl -k -s -o /dev/null -w %{http_code} $CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/) = 200 ]]; then
+  if [[ $(curl -k -s -o /dev/null -w %{http_code} $CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/connectors) = 200 ]]; then
     echo "Woohoo! Kafka Connect with SSL listener is up!"
     exit 0
   else 
-    echo -e $(date) "\tKafka Connect with SSL listener HTTP state: " $(curl -k -s -o /dev/null -w %{http_code} http://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/) " (waiting for 200)"
+    echo -e $(date) "\tKafka Connect with SSL listener HTTP state: " $(curl -k -s -o /dev/null -w %{http_code} http://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/connectors) " (waiting for 200)"
     exit 1
   fi
 fi

--- a/debian/kafka-connect-base/include/etc/confluent/docker/healthcheck.sh
+++ b/debian/kafka-connect-base/include/etc/confluent/docker/healthcheck.sh
@@ -5,7 +5,7 @@ if [[ -z $CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM ]]; then
     echo "Woohoo! Kafka Connect is up!"
     exit 0
   else 
-    echo -e $(date) "\tKafka Connect HTTP state: " $(curl -s -o /dev/null -w %{http_code} $CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/info) " (waiting for 200)"
+    echo -e $(date) "\tKafka Connect HTTP state: " $(curl -s -o /dev/null -w %{http_code} $CONNECT_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/) " (waiting for 200)"
     exit 1
   fi
 else
@@ -13,7 +13,7 @@ else
     echo "Woohoo! Kafka Connect with SSL listener is up!"
     exit 0
   else 
-    echo -e $(date) "\tKafka Connect with SSL listener HTTP state: " $(curl -k -s -o /dev/null -w %{http_code} http://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/info) " (waiting for 200)"
+    echo -e $(date) "\tKafka Connect with SSL listener HTTP state: " $(curl -k -s -o /dev/null -w %{http_code} http://$CONNECT_REST_ADVERTISED_HOST_NAME:$CONNECT_REST_PORT/) " (waiting for 200)"
     exit 1
   fi
 fi


### PR DESCRIPTION
This adds support for the Healthcheck functionality in Docker to Kafka Connect, enabling more accurate orchestration and management of containers. 

It works with both HTTP and HTTPS. 

There is a five-second polling interval, which is therefore the maximum that this would add to any dependents in starting. 

(supersedes https://github.com/confluentinc/cp-docker-images/pull/742)

## Testing done

### No SSL

Using [zero-to-hero](https://github.com/confluentinc/demo-scene/tree/master/kafka-connect-zero-to-hero), mounted the healthcheck script as an external file, and added `healthcheck` to the Docker Compose: 

    healthcheck:
      timeout: 10s
      # 60 * 5s retries = five minutes
      interval: 5s
      retries: 120
      test: /etc/confluent/docker/healthcheck.sh
    volumes:
      - /Users/Robin/git/cp-docker-images/debian/kafka-connect-base/include/etc/confluent/docker/healthcheck.sh:/etc/confluent/docker/healthcheck.sh

Ran `docker-compose up -d`. 

Monitor healthcheck status: 

    $ docker inspect kafka-connect-01|jq '.[].State.Health'
    {
      "Status": "healthy",
      "FailingStreak": 0,
      "Log": [
        {
          "Start": "2019-07-24T10:57:11.1432877Z",
          "End": "2019-07-24T10:57:13.3144807Z",
          "ExitCode": 1,
          "Output": "Wed Jul 24 10:57:12 UTC 2019 \tKafka Connect HTTP state:  000  (waiting for 200)\n"
        },
        {
          "Start": "2019-07-24T10:57:18.3804919Z",
          "End": "2019-07-24T10:57:20.8000458Z",
          "ExitCode": 0,
          "Output": "Woohoo! Kafka Connect is up!\n"
        },

Container shows as `healthy`: 

    $ docker ps
    CONTAINER ID        IMAGE                                                 COMMAND                   CREATED             STATUS                   PORTS                                                      NAMES
    97bb1d396845        confluentinc/cp-enterprise-control-center:5.3.0       "bash -c 'echo \"Wait…"   4 minutes ago       Up 4 minutes             0.0.0.0:9021->9021/tcp                                     control-center
    04585a48c8e8        confluentinc/cp-ksql-cli:5.3.0                        "/bin/sh"                 4 minutes ago       Up 4 minutes                                                                        ksql-cli
    f7766e11d4d4        confluentinc/ksql-examples:5.1.2                      "bash -c 'echo Waiti…"    4 minutes ago       Up 4 minutes                                                                        datagen-ratings
    71f5a677268b        confluentinc/cp-kafka-connect:5.3.0                   "bash -c 'echo \"Inst…"   4 minutes ago       Up 4 minutes (healthy)   0.0.0.0:8083->8083/tcp, 9092/tcp                           kafka-connect-01
    […]

### With SSL

Using [cp-demo](https://github.com/confluentinc/cp-demo/), mounted the healthcheck script as an external file, and added `healthcheck` paragraph to the Docker Compose: 

    healthcheck:
      timeout: 10s
      # 60 * 5s retries = five minutes
      interval: 5s
      retries: 120
      test: /etc/confluent/docker/healthcheck.sh
    volumes:
      - /Users/Robin/git/cp-docker-images/debian/kafka-connect-base/include/etc/confluent/docker/healthcheck.sh:/etc/confluent/docker/healthcheck.sh
      […]

Ran `docker-compose up -d`. 

Monitor healthcheck status: 

    $ docker inspect connect|jq '.[].State.Health'
    {
      "Status": "healthy",
      "FailingStreak": 0,
      "Log": [
        {
          "Start": "2019-07-24T10:43:29.5857643Z",
          "End": "2019-07-24T10:43:38.5754631Z",
          "ExitCode": 1,
          "Output": "Wed Jul 24 10:43:38 UTC 2019 \tKafka Connect with SSL listener HTTP state:  000  (waiting for 200)\n"
        },
        {
          "Start": "2019-07-24T10:43:43.5995865Z",
          "End": "2019-07-24T10:43:45.8553504Z",
          "ExitCode": 0,
          "Output": "Woohoo! Kafka Connect with SSL listener is up!\n"
        },

Container shows as `healthy`: 

    $ docker ps
    CONTAINER ID        IMAGE                                                 COMMAND                  CREATED             STATUS                   PORTS                                                        NAMES
    03cd73bc6ff5        docker.elastic.co/kibana/kibana:5.5.2                 "/bin/sh -c /usr/loc…"   3 minutes ago       Up 3 minutes             0.0.0.0:5601->5601/tcp                                       kibana
    14545dea8585        confluentinc/cp-ksql-cli:5.3.0                        "/bin/sh"                3 minutes ago       Up 3 minutes                                                                          ksql-cli
    5d920ec3d2a3        docker.elastic.co/elasticsearch/elasticsearch:5.6.0   "/bin/bash bin/es-do…"   3 minutes ago       Up 3 minutes             0.0.0.0:9200->9200/tcp, 0.0.0.0:9300->9300/tcp               elasticsearch
    7c2a6e00ca81        confluentinc/cp-enterprise-control-center:5.3.0       "/etc/confluent/dock…"   3 minutes ago       Up 3 minutes             0.0.0.0:9021-9022->9021-9022/tcp                             control-center
    e0b56a3c343e        confluentinc/cp-ksql-server:5.3.0                     "/etc/confluent/dock…"   3 minutes ago       Up 3 minutes             0.0.0.0:8088->8088/tcp                                       ksql-server
    d1f5ad6e1d30        confluentinc/cp-kafka-connect:5.3.0                   "/etc/confluent/dock…"   3 minutes ago       Up 3 minutes (healthy)   0.0.0.0:8083->8083/tcp, 9092/tcp                             connect
    8265c8322bd0        confluentinc/cp-kafka-rest:5.3.0                      "/etc/confluent/dock…"   39 minutes ago      Up 37 minutes            8082/tcp, 0.0.0.0:8086->8086/tcp                             restproxy
    […]
