### PR TITLE
Set correct KAFKA_VERSION value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CONFLUENT_PATCH_VERSION ?= 0
 
 CONFLUENT_VERSION ?= ${CONFLUENT_MAJOR_VERSION}.${CONFLUENT_MINOR_VERSION}.${CONFLUENT_PATCH_VERSION}
 
-KAFKA_VERSION ?= 5.3.0
+KAFKA_VERSION ?= 2.3.0
 
 COMPONENTS := base zookeeper kafka server kafka-rest schema-registry kafka-connect-base kafka-connect server-connect-base server-connect enterprise-control-center kafkacat enterprise-replicator enterprise-replicator-executable enterprise-kafka kafka-mqtt
 COMMIT_ID := $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
The KAFKA_VERSION seems to have been set to the confluent version and not the version of the Kafka broker used.