### PR TITLE
DOCS-2187 Fixed links CP Docker Images docs-customer feedback

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,4 +1,4 @@
-.. _development :
+.. _development:
 
 Developer Guide
 ===========
@@ -8,7 +8,7 @@ Developer Guide
 .. contents::
   :local:
 
-.. _image_design_overview :
+.. _image_design_overview:
 
 Image Design Overview
 ---------------------
@@ -70,7 +70,7 @@ We adhered to the following guidelines when developing these Docker bootup scrip
 3. Fail with Good Error Messages
 4. Return 0 if success, 1 if fail
 
-.. _setup :
+.. _setup:
 
 Setup
 -----
@@ -167,7 +167,7 @@ Push to the Docker hub:
 
 ``push-public``
 
-.. _extending_images :
+.. _extending_images:
 
 Extending the Docker Images
 --------------------------
@@ -175,7 +175,7 @@ Extending the Docker Images
 You may want to extend the images to add new software, change the
 config management, use service discovery etc.  This page provides instructions for doing so. 
 
-.. _prerequisites :
+.. _prerequisites:
 
 Prerequisites
 ~~~~~~~~~~~~
@@ -197,7 +197,7 @@ There are currently two ways to add new connectors to the Kafka Connect image.
 * Build a new Docker image that has connector installed. You can follow example 2 in the documentation below. You will need to make sure that the connector jars are on the classpath. 
 * Add the connector jars via volumes.  If you don't want to create a new Docker image, please see our documentation on `Configuring Kafka Connect with External Jars <operations/external-volumes.html>`_ to configure the `cp-kafka-connect` container with external jars.
 
-.. _examples :
+.. _examples:
 
 Examples
 ~~~~~~~~
@@ -245,7 +245,7 @@ The following examples show to extend the images.
           docker build -t foo/zookeeper:latest .
 
 
-  Run it :
+  Run it:
 
   .. sourcecode:: bash
 

--- a/docs/operations/external-volumes.rst
+++ b/docs/operations/external-volumes.rst
@@ -1,4 +1,4 @@
-.. _external_volumes :
+.. _external_volumes:
 
 Mounting External Volumes
 -------------------------
@@ -12,12 +12,12 @@ When working with Docker, you may sometimes need to persist data in the event of
 
   .. note::
 
-    In the event that you need to add support for additional use cases for external volumes, please refer to our guide on `extending the images <../development.html#extending-the-docker-images>`_.
+    In the event that you need to add support for additional use cases for external volumes, please refer to our guide on :ref:`extending the images <extending_images>`.
 
 Data Volumes for Kafka & Zookeeper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Kafka uses volumes for log data and Zookeeper uses volumes for transaction logs. It is recommended to seperate volumes (on the host) for these services. You will also need to ensure that the host directory has read/write permissions for the Docker container user (which is root by default unless you assign a user using Docker run command).
+Kafka uses volumes for log data and Zookeeper uses volumes for transaction logs. It is recommended to separate volumes (on the host) for these services. You will also need to ensure that the host directory has read/write permissions for the Docker container user (which is root by default unless you assign a user using Docker run command).
 
 Below is an example of how to use Kafka and Zookeeper with mounted volumes. We also show how to configure volumes if you are running Docker container as non root user. In this example, we run the container as user 12345.
 

--- a/docs/operations/logging.rst
+++ b/docs/operations/logging.rst
@@ -1,7 +1,7 @@
 Configuring logging
 -------------
 
-All logs are sent to ``stdout`` by default. You can change this by `extending the images <development.html/_extending_images>`_. 
+All logs are sent to ``stdout`` by default. You can change this by `extending the images <../development.html#extending_images>`_. 
 
 log4j Log Levels
 ~~~~~~~~~~~~~~~~

--- a/docs/operations/logging.rst
+++ b/docs/operations/logging.rst
@@ -1,7 +1,7 @@
 Configuring logging
 -------------
 
-All logs are sent to ``stdout`` by default. You can change this by `extending the images <../development.html#extending_images>`_. 
+All logs are sent to ``stdout`` by default. You can change this by :ref:`extending the images <extending_images>`.
 
 log4j Log Levels
 ~~~~~~~~~~~~~~~~

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -5,7 +5,7 @@ Quickstart
 
 In this section, we provide a simple guide for running a Kafka cluster along with all of the other Confluent Platform components.  By the end of this quickstart, you will have successfully installed and run a simple deployment including each component with Docker.
 
-In order to keep things simple, this quickstart guide is limited to a single node Confluent Platform cluster.  For more advanced tutorials, you can refer to the `tutorials section <tutorials.html>`_ of this documentation.
+In order to keep things simple, this quickstart guide is limited to a single node Confluent Platform cluster.  For more advanced tutorials, you can refer to the `tutorials section <tutorials/tutorials.html>`_ of this documentation.
 
 It is also worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  However, you can also refer to our `documentation on Docker external volumes <operations/external-volumes.html>`_ for an example of how to add mounted volumes to the host machine to persist data in the event that the container stops running.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -5,9 +5,9 @@ Quickstart
 
 In this section, we provide a simple guide for running a Kafka cluster along with all of the other Confluent Platform components.  By the end of this quickstart, you will have successfully installed and run a simple deployment including each component with Docker.
 
-In order to keep things simple, this quickstart guide is limited to a single node Confluent Platform cluster.  For more advanced tutorials, you can refer to the `tutorials section <tutorials/tutorials.html>`_ of this documentation.
+In order to keep things simple, this quickstart guide is limited to a single node Confluent Platform cluster.  For more advanced tutorials, you can refer to the :ref:`tutorials section <tutorials_overview>` of this documentation.
 
-It is also worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  However, you can also refer to our `documentation on Docker external volumes <operations/external-volumes.html>`_ for an example of how to add mounted volumes to the host machine to persist data in the event that the container stops running.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.
+It is also worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  However, you can also refer to our :ref:`documentation on Docker external volumes <external_volumes>` for an example of how to add mounted volumes to the host machine to persist data in the event that the container stops running.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.
 
 Installing & Running Docker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/automatic-data-balancing.rst
+++ b/docs/tutorials/automatic-data-balancing.rst
@@ -5,7 +5,7 @@ Automatic Data Balancing
 
 In this section, we provide a tutorial for running Confluent Auto Data Balancing on Kafka which allows you to shift data to create an even workload across your cluster.  By the end of this tutorial, you will have successfully run Confluent Auto Data Balancing CLI to rebalance data after adding and removing brokers.
 
-It is worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  For production deployments (or generally whenever you care about not losing data), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.  Refer to our `documentation on Docker external volumes <operations/external-volumes.html>`_ for an example of how to add mounted volumes to the host machine.
+It is worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  For production deployments (or generally whenever you care about not losing data), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.  Refer to our :ref:`documentation on Docker external volumes <external_volumes>` for an example of how to add mounted volumes to the host machine.
 
 Installing & Running Docker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/automatic-data-balancing.rst
+++ b/docs/tutorials/automatic-data-balancing.rst
@@ -1,4 +1,4 @@
-.. _automatic_data_balancing :
+.. _automatic_data_balancing:
 
 Automatic Data Balancing
 ------------------------

--- a/docs/tutorials/clustered-deployment-sasl.rst
+++ b/docs/tutorials/clustered-deployment-sasl.rst
@@ -7,7 +7,7 @@ In this section, we provide a tutorial for running a secure three-node Kafka clu
 
   .. note::
 
-    It is worth noting that we will be configuring Kafka and Zookeeper to store secrets locally in the Docker containers.  For production deployments (or generally whenever you care about not losing data), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.  Refer to our `documentation on Docker external volumes <operations/external-volumes.html>`_ for an example of how to add mounted volumes to the host machine.
+    It is worth noting that we will be configuring Kafka and Zookeeper to store secrets locally in the Docker containers.  For production deployments (or generally whenever you care about not losing data), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.  Refer to our :ref:`documentation on Docker external volumes <external_volumes>` for an example of how to add mounted volumes to the host machine.
 
 Installing & Running Docker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/clustered-deployment-ssl.rst
+++ b/docs/tutorials/clustered-deployment-ssl.rst
@@ -7,7 +7,7 @@ In this section, we provide a tutorial for running a secure three-node Kafka clu
 
   .. note::
 
-    It is worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  For production deployments (or generally whenever you care about not losing data), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.  Refer to our `documentation on Docker external volumes <operations/external-volumes.html>`_ for an example of how to add mounted volumes to the host machine.
+    It is worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  For production deployments (or generally whenever you care about not losing data), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.  Refer to our :ref:`documentation on Docker external volumes <external_volumes>` for an example of how to add mounted volumes to the host machine.
 
 Installing & Running Docker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/clustered-deployment.rst
+++ b/docs/tutorials/clustered-deployment.rst
@@ -1,4 +1,4 @@
-.. _clustered_quickstart :
+.. _clustered_quickstart:
 
 Clustered Deployment
 --------------------

--- a/docs/tutorials/clustered-deployment.rst
+++ b/docs/tutorials/clustered-deployment.rst
@@ -9,7 +9,7 @@ In this section, we provide a tutorial for running a three-node Kafka cluster an
 
     If you're looking for a simpler tutorial, please `refer to our quickstart guide <../quickstart.html>`_, which is limited to a single node Kafka cluster.
 
-It is worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  For production deployments (or generally whenever you care about not losing data), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.  Refer to our `documentation on Docker external volumes <operations/external-volumes.html>`_ for an example of how to add mounted volumes to the host machine.
+It is worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  For production deployments (or generally whenever you care about not losing data), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.  Refer to our :ref:`documentation on Docker external volumes <external_volumes>` for an example of how to add mounted volumes to the host machine.
 
 Installing & Running Docker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/connect-avro-jdbc.rst
+++ b/docs/tutorials/connect-avro-jdbc.rst
@@ -9,7 +9,7 @@ In the `quickstart guide  <../quickstart.html>`_, we showed you how to get up an
 
     Schema Registry is a dependency for Connect in this tutorial because we will need it for the avro serializer functionality. 
 
-It is worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  For production deployments (or generally whenever you care about not losing data), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.  Refer to our `documentation on Docker external volumes <operations/external-volumes.html>`_ for an example of how to add mounted volumes to the host machine.   
+It is worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  For production deployments (or generally whenever you care about not losing data), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages.  Refer to our :ref:`documentation on Docker external volumes <external_volumes>` for an example of how to add mounted volumes to the host machine.   
 
 Installing & Running Docker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/replicator.rst
+++ b/docs/tutorials/replicator.rst
@@ -1,4 +1,4 @@
-.. _replicator :
+.. _replicator:
 
 Replicator Tutorial
 -------------------

--- a/docs/tutorials/replicator.rst
+++ b/docs/tutorials/replicator.rst
@@ -5,7 +5,7 @@ Replicator Tutorial
 
 In this section, we provide a tutorial for running Replicator which replicates data from two source Kafka clusters to a destination Kafka cluster.  By the end of this tutorial, you will have successfully run Replicator and replicated data for two topics from different source clusters to a destination cluster.  Furthermore, you will have also set up a Kafka Connect cluster because Replicator is built on Connect.
 
-It is worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  For deployments that require persistent data (e.g. production deployments), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages. Refer to our `documentation on Docker external volumes <operations/external-volumes.html>`_ for an example of how to add mounted volumes to the host machine.
+It is worth noting that we will be configuring Kafka and Zookeeper to store data locally in the Docker containers.  For deployments that require persistent data (e.g. production deployments), you should use mounted volumes for persisting data in the event that a container stops running or is restarted.  This is important when running a system like Kafka on Docker, as it relies heavily on the filesystem for storing and caching messages. Refer to our :ref:`documentation on Docker external volumes <external_volumes>` for an example of how to add mounted volumes to the host machine.
 
 Installing & Running Docker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/tutorials.rst
+++ b/docs/tutorials/tutorials.rst
@@ -1,4 +1,4 @@
-.. _tutorials_overview :
+.. _tutorials_overview:
 
 More Tutorials
 ==============


### PR DESCRIPTION
## Description

https://confluentinc.atlassian.net/browse/DOCS-2187

- Fixed link to "extending Docker images" which is broken on [v.3.1.0](https://docs.confluent.io/3.1.0/cp-docker-images/docs/operations/logging.html#), 3.1.1, 3.1.2, 3.2.0, and 3.0.1 docs (won't fix 3.0.1, will fix others via `pint merge`)

- Fixed link to "tutorials section" which is broken on [v.3.1.0](https://docs.confluent.io/3.1.0/cp-docker-images/docs/quickstart.html), 3.1.1,  3.1.2, 3.2.0, and 3.0.1 docs (won't fix 3.0.1, will fix others via `pint merge`)

Signed-off-by: Victoria Bialas <vicky@confluent.io>