### PR TITLE
add security plugins for schema validator to cp-server

### DIFF
--- a/debian/server/Dockerfile
+++ b/debian/server/Dockerfile
@@ -39,6 +39,9 @@ RUN echo "===> installing ${COMPONENT}..." \
     && echo "===> installing confluent-rebalancer ..." \
     && apt-get update && apt-get install -y \
               confluent-rebalancer=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> installing confluent-security ..." \
+    && apt-get update && apt-get install -y \
+              confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     \
     && echo "===> clean up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \


### PR DESCRIPTION
With Schema Validator, we now need the security-plugins installed on the broker image itself.  This will install confluent-security into the cp-server image.

Signed-off-by: sdanduConf <sdandu@confluent.io>