### PR TITLE
adding a zookeeper observer property to zookeeper.properties.template

### DIFF
--- a/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
+++ b/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
@@ -26,7 +26,8 @@ dataLogDir=/var/lib/zookeeper/log
   'ZOOKEEPER_FORCE_SYNC': 'forceSync',
   'ZOOKEEPER_JUTE_MAX_BUFFER': 'jute.maxbuffer',
   'ZOOKEEPER_SKIP_ACL': 'skipACL',
-  'ZOOKEEPER_QUORUM_LISTEN_ON_ALL_IPS': 'quorumListenOnAllIPs'
+  'ZOOKEEPER_QUORUM_LISTEN_ON_ALL_IPS': 'quorumListenOnAllIPs',
+  'ZOOKEEPER_PEER_TYPE': 'peerType'
  } -%}
 
 {% for k, property in other_props.iteritems() -%}


### PR DESCRIPTION
Adding a property to allow zookeeper to run as an observer.