### PR TITLE
add snapshot.trust.empty and admin.enableServer to zookeeper.properties.template

### DIFF
--- a/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
+++ b/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
@@ -27,7 +27,8 @@ dataLogDir=/var/lib/zookeeper/log
   'ZOOKEEPER_JUTE_MAX_BUFFER': 'jute.maxbuffer',
   'ZOOKEEPER_SKIP_ACL': 'skipACL',
   'ZOOKEEPER_QUORUM_LISTEN_ON_ALL_IPS': 'quorumListenOnAllIPs',
-  'ZOOKEEPER_SNAPSHOT_TRUST_EMPTY': 'snapshot.trust.empty'
+  'ZOOKEEPER_SNAPSHOT_TRUST_EMPTY': 'snapshot.trust.empty',
+  'ZOOKEEPER_ADMIN_ENABLESERVER': 'admin.enableServer'
  } -%}
 
 {% for k, property in other_props.iteritems() -%}

--- a/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
+++ b/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
@@ -26,7 +26,8 @@ dataLogDir=/var/lib/zookeeper/log
   'ZOOKEEPER_FORCE_SYNC': 'forceSync',
   'ZOOKEEPER_JUTE_MAX_BUFFER': 'jute.maxbuffer',
   'ZOOKEEPER_SKIP_ACL': 'skipACL',
-  'ZOOKEEPER_QUORUM_LISTEN_ON_ALL_IPS': 'quorumListenOnAllIPs'
+  'ZOOKEEPER_QUORUM_LISTEN_ON_ALL_IPS': 'quorumListenOnAllIPs',
+  'ZOOKEEPER_SNAPSHOT_TRUST_EMPTY': 'snapshot.trust.empty'
  } -%}
 
 {% for k, property in other_props.iteritems() -%}


### PR DESCRIPTION
Hi,

I've checked upgrade guide to upgrade 5.3 to 5.4.  It turns out that we need to add snapshot.trust.empty to the zookeeper config.

https://docs.confluent.io/current/installation/upgrade.html#additional-zk-upgrade-information

This PR adds `snapshot.trust.empty` and `admin.enableServer` to zookeeper.properties.