### PR TITLE
Adding 4 letter word command whitelisting option for docker images.

### DIFF
--- a/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
+++ b/debian/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
@@ -26,7 +26,8 @@ dataLogDir=/var/lib/zookeeper/log
   'ZOOKEEPER_FORCE_SYNC': 'forceSync',
   'ZOOKEEPER_JUTE_MAX_BUFFER': 'jute.maxbuffer',
   'ZOOKEEPER_SKIP_ACL': 'skipACL',
-  'ZOOKEEPER_QUORUM_LISTEN_ON_ALL_IPS': 'quorumListenOnAllIPs'
+  'ZOOKEEPER_QUORUM_LISTEN_ON_ALL_IPS': 'quorumListenOnAllIPs',
+  'ZOOKEEPER_4LW_COMMANDS_WHITELIST': '4lw.commands.whitelist'
  } -%}
 
 {% for k, property in other_props.iteritems() -%}


### PR DESCRIPTION
It is required to add 4 letter word whitelisting variable in the zookeeper config after 3.4.10. 

Updating template file to accept `4lw.commands.whitelist` config.

Reference: https://zookeeper.apache.org/doc/r3.4.10/zookeeperAdmin.html