### PR TITLE
Arm64 Support

### DIFF
--- a/bin/build-debian
+++ b/bin/build-debian
@@ -30,7 +30,9 @@ for component in ${COMPONENTS} ; do
         BUILD_ARGS=""
     fi
 
-    for type in "" rpm; do
+    #TODO: undo this... only building debian images for now
+    #for type in "" rpm; do
+    for type in ""; do
         DOCKER_FILE="debian/${component}/Dockerfile"
         COMPONENT_NAME=${component}
 
@@ -43,12 +45,13 @@ for component in ${COMPONENTS} ; do
         fi
 
         if [ -a "${DOCKER_FILE}" ]; then
-            docker build --build-arg KAFKA_VERSION=${KAFKA_VERSION} --build-arg CONFLUENT_PLATFORM_LABEL=${CONFLUENT_PLATFORM_LABEL} --build-arg CONFLUENT_MAJOR_VERSION=${CONFLUENT_MAJOR_VERSION} --build-arg CONFLUENT_MINOR_VERSION=${CONFLUENT_MINOR_VERSION} --build-arg CONFLUENT_PATCH_VERSION=${CONFLUENT_PATCH_VERSION} --build-arg COMMIT_ID=${COMMIT_ID} --build-arg BUILD_NUMBER=${BUILD_NUMBER} ${BUILD_ARGS} -t ${REPOSITORY}/cp-${COMPONENT_NAME}:latest -f ${DOCKER_FILE} debian/${component} || exit 1
+            docker buildx build --platform=linux/arm64,linux/amd64 --pull --build-arg KAFKA_VERSION=${KAFKA_VERSION} --build-arg CONFLUENT_PLATFORM_LABEL=${CONFLUENT_PLATFORM_LABEL} --build-arg CONFLUENT_MAJOR_VERSION=${CONFLUENT_MAJOR_VERSION} --build-arg CONFLUENT_MINOR_VERSION=${CONFLUENT_MINOR_VERSION} --build-arg CONFLUENT_PATCH_VERSION=${CONFLUENT_PATCH_VERSION} --build-arg COMMIT_ID=${COMMIT_ID} --build-arg BUILD_NUMBER=${BUILD_NUMBER} ${BUILD_ARGS} --build-arg REPOSITORY=${REPOSITORY} -t ${REPOSITORY}/cp-${COMPONENT_NAME}:latest --push -f ${DOCKER_FILE} debian/${component} || exit 1
 
-            docker tag ${REPOSITORY}/cp-${COMPONENT_NAME}:latest ${REPOSITORY}/cp-${COMPONENT_NAME}:latest  || exit 1
-            docker tag ${REPOSITORY}/cp-${COMPONENT_NAME}:latest ${REPOSITORY}/cp-${COMPONENT_NAME}:${CONFLUENT_VERSION}${CONFLUENT_MVN_LABEL} || exit 1
-            docker tag ${REPOSITORY}/cp-${COMPONENT_NAME}:latest ${REPOSITORY}/cp-${COMPONENT_NAME}:${VERSION} || exit 1
-            docker tag ${REPOSITORY}/cp-${COMPONENT_NAME}:latest ${REPOSITORY}/cp-${COMPONENT_NAME}:${COMMIT_ID} || exit 1
+            #TODO: Don't want to use docker tag with buildx image, need to work with the manifest, use something like docker manifest cp?
+            #docker manifest inspect ${REPOSITORY}/cp-${COMPONENT_NAME}:latest
+            #Take the manifest digests out of the manifest list, then:
+            #docker manifest create ${REPOSITORY}/cp-${COMPONENT_NAME}:${VERSION} ${REPOSITORY}/cp-${COMPONENT_NAME}@sha256:...1 ${REPOSITORY}/cp-${COMPONENT_NAME}@sha256:...2 ${REPOSITORY}/cp-${COMPONENT_NAME}@sha256:...3
+            #docker manifest push ${REPOSITORY}/cp-${COMPONENT_NAME}:${VERSION}
         fi;
     done
 done

--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -78,11 +78,8 @@ RUN echo "===> Updating debian ....." \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
     && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
     && apt remove --purge -y git \
-    && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
-    && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \
-    && echo "deb http://repos.azulsystems.com/debian stable  main" >> /etc/apt/sources.list.d/zulu.list \
-    && apt-get -qq update \
-    && apt-get -y install zulu-${ZULU_OPENJDK_VERSION} \
+    && echo "Installing OpenJDK" \
+    && apt-get -y install openjdk-11-jdk \
     && echo "===> Installing Kerberos Patch ..." \
     && DEBIAN_FRONTEND=noninteractive apt-get -y install krb5-user \
     && rm -rf /var/lib/apt/lists/* \

--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:stable
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
@@ -30,7 +30,7 @@ MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 
 # Python
-ENV PYTHON_VERSION="2.7.9-1"
+ENV PYTHON_VERSION="2.7.16-1"
 ENV PYTHON_PIP_VERSION="8.1.2"
 
 # Confluent
@@ -63,16 +63,12 @@ ENV ZULU_OPENJDK_VERSION="8=8.38.0.13"
 ENV LANG="C.UTF-8"
 
 RUN echo "===> Updating debian ....." \
-    # TODO debian jessie has been deprecated and is only ex
-    && echo "deb http://archive.debian.org/debian/ jessie main" > /etc/apt/sources.list \
-    && echo "deb http://security.debian.org jessie/updates main" >> /etc/apt/sources.list \
     && apt-get -qq update \
-    \
     && echo "===> Installing curl wget netcat python...." \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 apt-transport-https \
                 curl \
-                gnupg-curl \
+                gnupg \
                 git \
                 wget \
                 netcat \

--- a/debian/enterprise-control-center/Dockerfile
+++ b/debian/enterprise-control-center/Dockerfile
@@ -15,7 +15,8 @@
 
 # Builds a docker image for the Confluent Control Center.
 
-FROM confluentinc/cp-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-base
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/debian/enterprise-control-center/Dockerfile.rpm
+++ b/debian/enterprise-control-center/Dockerfile.rpm
@@ -15,7 +15,8 @@
 
 # Builds a docker image for the Confluent Control Center.
 
-FROM confluentinc/cp-rpm-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-rpm-base
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/debian/enterprise-kafka/Dockerfile
+++ b/debian/enterprise-kafka/Dockerfile
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM confluentinc/cp-kafka
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-kafka
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/debian/enterprise-kafka/Dockerfile.rpm
+++ b/debian/enterprise-kafka/Dockerfile.rpm
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM confluentinc/cp-rpm-kafka
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-rpm-kafka
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/debian/enterprise-replicator-executable/Dockerfile
+++ b/debian/enterprise-replicator-executable/Dockerfile
@@ -15,7 +15,8 @@
 
 # Builds a docker image for Replicator
 
-FROM confluentinc/cp-enterprise-replicator
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-enterprise-replicator
 
 MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true

--- a/debian/enterprise-replicator/Dockerfile
+++ b/debian/enterprise-replicator/Dockerfile
@@ -15,7 +15,8 @@
 
 # Builds a docker image for Replicator
 
-FROM confluentinc/cp-server-connect-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-server-connect-base
 
 MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true

--- a/debian/kafka-connect-base/Dockerfile
+++ b/debian/kafka-connect-base/Dockerfile
@@ -15,7 +15,8 @@
 
 # Builds a docker image for Kafka Connect
 
-FROM confluentinc/cp-kafka
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-kafka
 
 MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true

--- a/debian/kafka-connect/Dockerfile
+++ b/debian/kafka-connect/Dockerfile
@@ -15,7 +15,8 @@
 
 # Builds a docker image for Kafka Connect
 
-FROM confluentinc/cp-kafka-connect-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-kafka-connect-base
 
 MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true

--- a/debian/kafka-mqtt/Dockerfile
+++ b/debian/kafka-mqtt/Dockerfile
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM confluentinc/cp-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-base
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/debian/kafka-rest/Dockerfile
+++ b/debian/kafka-rest/Dockerfile
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM confluentinc/cp-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-base
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/debian/kafka/Dockerfile
+++ b/debian/kafka/Dockerfile
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM confluentinc/cp-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-base
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/debian/kafka/Dockerfile.rpm
+++ b/debian/kafka/Dockerfile.rpm
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM confluentinc/cp-rpm-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-rpm-base
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/debian/schema-registry/Dockerfile
+++ b/debian/schema-registry/Dockerfile
@@ -15,7 +15,8 @@
 
 # Builds a docker image for the Confluent Schema Registry.
 
-FROM confluentinc/cp-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-base
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/debian/server-connect-base/Dockerfile
+++ b/debian/server-connect-base/Dockerfile
@@ -15,7 +15,8 @@
 
 # Builds a docker image for Kafka Connect
 
-FROM confluentinc/cp-server
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-server
 
 MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true

--- a/debian/server-connect/Dockerfile
+++ b/debian/server-connect/Dockerfile
@@ -15,7 +15,8 @@
 
 # Builds a docker image for Kafka Connect
 
-FROM confluentinc/cp-server-connect-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-server-connect-base
 
 MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true

--- a/debian/server/Dockerfile
+++ b/debian/server/Dockerfile
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM confluentinc/cp-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-base
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/debian/server/Dockerfile.rpm
+++ b/debian/server/Dockerfile.rpm
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM confluentinc/cp-rpm-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-rpm-base
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/debian/zookeeper/Dockerfile
+++ b/debian/zookeeper/Dockerfile
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM confluentinc/cp-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-base
 
 EXPOSE 2181 2888 3888
 

--- a/debian/zookeeper/Dockerfile.rpm
+++ b/debian/zookeeper/Dockerfile.rpm
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM confluentinc/cp-rpm-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-rpm-base
 
 EXPOSE 2181 2888 3888
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>

--- a/tests/images/jmxterm/Dockerfile
+++ b/tests/images/jmxterm/Dockerfile
@@ -1,4 +1,5 @@
-FROM confluentinc/cp-base
+ARG REPOSITORY=confluentinc
+FROM $REPOSITORY/cp-base
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID


### PR DESCRIPTION
Basic working zookeeper and kafka docker images for arm64 platform.  Resolves #718 

There are still a handful of TODOs before this is ready to merge but I'm hoping to get some feedback on the basic changes and if this looks like a reasonable direction.

I've got docker images published at:

[kymeric/cp-base](https://hub.docker.com/repository/docker/kymeric/cp-base/general)
[kymeric/cp-zookeeper](https://hub.docker.com/repository/docker/kymeric/cp-zookeeper)
[kymeric/cp-kafka](https://hub.docker.com/repository/docker/kymeric/cp-kafka/general)

**Testing**:
I've run the following slightly-modified getting started commands on my raspberry pi 4 and everything works as expected.  I'll be testing more thoroughly over the next few weeks.

commands:
```bash
echo "Starting zookeeper and kafka for $(hostname)";
docker run -d  --name=zookeeper -e ZOOKEEPER_CLIENT_PORT=2181 -p 2181:2181 kymeric/cp-zookeeper
docker run -d --name=kafka -e KAFKA_ZOOKEEPER_CONNECT=$(hostname):2181 -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://$(hostname):9092 -p 9092:9092 -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 kymeric/cp-kafka
echo "Sleeping for 20 seconds to let broker come up..."
sleep 20
echo "Creating topic: 'foo'"
docker run --rm "kymeric/cp-kafka:latest" kafka-topics --create --topic foo --partitions 1 --replication-factor 1 --if-not-exists --zookeeper $(hostname):2181
echo "Describing topic: 'foo'"
docker run --rm "kymeric/cp-kafka:latest" kafka-topics --describe --topic foo --zookeeper $(hostname):2181
echo "Producing 42 messages for: 'foo'"
docker run --rm "kymeric/cp-kafka:latest" bash -c "seq 42 | kafka-console-producer --request-required-acks 1 --broker-list $(hostname):9092 --topic foo && echo 'Produced 42 messages.'"
echo "Killing zookeeper and kafka"
docker rm -f zookeeper kafka
```

os:
```
ubuntu@pi4b:~$ uname -a
Linux pi4b 5.3.0-1017-raspi2 #19-Ubuntu SMP Thu Jan 16 18:25:50 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
ubuntu@pi4b:~$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 19.10
Release:        19.10
Codename:       eoan
```

output:
```
Starting zookeeper and kafka for pi4b
03bb21c35d349e0a8dd5d63420aa6e0781b6e110fa8047a6b229b888836dd9b6
8b7bb902fd6076ff2d9a5068c35bef96bf86cec95d89e427e9d4f4bf95c4499e
Sleeping for 20 seconds to let broker come up...
Creating topic: 'foo'
Created topic foo.
Describing topic: 'foo'
Topic:foo       PartitionCount:1        ReplicationFactor:1     Configs:
        Topic: foo      Partition: 0    Leader: 1001    Replicas: 1001  Isr: 1001
producing 42 messages to: 'foo'
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Produced 42 messages.
Killing zookeeper and kafka
zookeeper
kafka
```


Comments welcome and appreciated.

**Changes**:
- Initial arm64 support
- Switch from `debian:jessie` to `debbian:stable` (Jessie not available for arm64`)
- Switch to openjdk-11, zulu not available for arm64?
- Parameterize Docker 'FROM' to use $REPOSITORY, default to 'confluentinc', pass to docker as build-arg from build-debian script

**Build**:
- Ubuntu >= 18.04? (I was using 19.10)
- docker >= 19.03.5
- `apt install qemu-user qemu-user-static make maven`
- enable experimental on docker daemon and client (for buildx)
- `docker buildx create --name mp --platform=linux/arm32,linux/arm64,linux/amd64 --use`
- `docker buildx inspect mp --bootstrap`
- `make build-debian REPOSITORY=kymeric COMPONENTS="base zookeeper kafka"`

**TODO**:
- Build/Test other components: I'm only working with zookeeper and kafka images.  I can easily build and publish these images but I will need help testing them
- Remove maven repository from pom.xml? (I imagine this shouldn't be needed but I got an error without it and the first issue I found mentioned this fix)
- I commented out the "rpm" type in the Makefile so I could focus on debian packages.  Need to check/verify all centos packages build and are cross-platform
- debian/base adds the confluent APT repository with [arch=amd64], but the packages seem to be architecture agnostic.  I'm not an APT expert, can we just remove [arch=amd64]?  Leaving it for now for some discussion with people who would know better
- Zulu cleanup?  Still see the zulu version variable in a few places
- Tag images with version label - Need to switch from `docker tag ...` to some `docker manifest create... push` commands, comments in build-debian.
- Add arm32 images?  I don't need these since I'm on arm64, I'm unsure if there's much demand for kafka on arm32.  But it would/should be easy to just add the arm32 platform