### PR TITLE
Update OS and various bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ push-private: clean build-debian build-test-images tag-remote
 ifndef DOCKER_REMOTE_REPOSITORY
 	$(error DOCKER_REMOTE_REPOSITORY must be defined.)
 endif
-	for image in `docker images -f label=io.confluent.docker.build.number -f "dangling=false" --format "{{.Repository}}:{{.Tag}}" | grep $$DOCKER_REMOTE_REPOSITORY` ; do \
+	for image in `docker images -f label=io.confluent.docker.build.number -f "dangling=false" --format "{{.Repository}}:{{.Tag}}" | grep $(DOCKER_REMOTE_REPOSITORY)` ; do \
         echo "\n Pushing $${image}"; \
         docker push $${image}; \
   done

--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -56,7 +56,7 @@ ENV CONFLUENT_VERSION="$CONFLUENT_MAJOR_VERSION.$CONFLUENT_MINOR_VERSION.$CONFLU
 ENV CONFLUENT_DEB_VERSION="1"
 
 # Zulu
-ENV ZULU_OPENJDK_VERSION="8=8.38.0.13"
+ENV ZULU_OPENJDK_VERSION="11"
 
 # This affects how strings in Java class files are interpreted.  We want UTF-8 and this is the only locale in the
 # base image that supports it

--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:stretch
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
@@ -30,7 +30,7 @@ MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 
 # Python
-ENV PYTHON_VERSION="2.7.9-1"
+ENV PYTHON_VERSION="2.7"
 ENV PYTHON_PIP_VERSION="8.1.2"
 
 # Confluent
@@ -64,28 +64,32 @@ ENV LANG="C.UTF-8"
 
 RUN echo "===> Updating debian ....." \
     # TODO debian jessie has been deprecated and is only ex
-    && echo "deb http://archive.debian.org/debian/ jessie main" > /etc/apt/sources.list \
-    && echo "deb http://security.debian.org jessie/updates main" >> /etc/apt/sources.list \
+    && echo "deb http://ftp.us.debian.org/debian stretch main" > \
+        /etc/apt/sources.list \
+    && echo "deb http://security.debian.org stretch/updates main" >> \
+        /etc/apt/sources.list \
     && apt-get -qq update \
-    \
     && echo "===> Installing curl wget netcat python...." \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 apt-transport-https \
                 curl \
-                gnupg-curl \
                 git \
                 wget \
                 netcat \
-                python=${PYTHON_VERSION} \
-                build-essential libssl-dev libffi-dev python-dev \
+                procps \
+                python${PYTHON_VERSION} \
+                build-essential libssl-dev libffi-dev \
+                python${PYTHON_VERSION}-dev \
     && echo "===> Installing python packages ..."  \
-    && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
+    && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | \
+           python${PYTHON_VERSION} \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
     && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
     && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \
-    && echo "deb http://repos.azulsystems.com/debian stable  main" >> /etc/apt/sources.list.d/zulu.list \
+    && echo "deb http://repos.azulsystems.com/debian stable  main" \
+         >> /etc/apt/sources.list.d/zulu.list \
     && apt-get -qq update \
     && apt-get -y install zulu-${ZULU_OPENJDK_VERSION} \
     && echo "===> Installing Kerberos Patch ..." \

--- a/debian/base/Dockerfile.rpm
+++ b/debian/base/Dockerfile.rpm
@@ -55,7 +55,7 @@ ENV CONFLUENT_PLATFORM_LABEL=$CONFLUENT_PLATFORM_LABEL
 ENV CONFLUENT_VERSION="$CONFLUENT_MAJOR_VERSION.$CONFLUENT_MINOR_VERSION.$CONFLUENT_PATCH_VERSION"
 
 # Zulu
-ENV ZULU_OPENJDK_VERSION="8-8.17.0.3"
+ENV ZULU_OPENJDK_VERSION="11"
 
 # This affects how strings in Java class files are interpreted.  We want UTF-8 and this is the only locale in the
 # base image that supports it

--- a/debian/base/Dockerfile.rpm
+++ b/debian/base/Dockerfile.rpm
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM centos:centos7
+FROM centos:centos8
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
@@ -70,10 +70,10 @@ RUN echo "===> Installing curl wget netcat python...." \
                 git \
                 wget \
                 nc \
-                python
+                python2
 
 RUN echo "===> Installing python packages ..."  \
-    && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
+    && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python2 \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
     && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
     && yum remove -y git

--- a/tests/images/kerberos/Dockerfile
+++ b/tests/images/kerberos/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6.6
+FROM centos:centos6.10
 
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID


### PR DESCRIPTION
Roll-forward to CentOS 6.10 to bring the container build back
into the realm of supported Linux.

The update to CentOS 7 (or 8) will require mitigation of any
dependencies of krb5-auth-dialog per its retirement in CentOS 7
and later.

Signed-off-by: Sven-Thorsten Dietrich <thebigcorporation@gmail.com>