### PR TITLE
fix: avoid leak of aws credentials on log

### DIFF
--- a/debian/base/include/etc/confluent/docker/bash-config
+++ b/debian/base/include/etc/confluent/docker/bash-config
@@ -24,5 +24,5 @@ fi
 
 
 function show_env {
-    env | sort | grep -vP 'PASSWORD|JAAS_CONFIG'
+    env | sort | grep -vP 'PASSWORD|JAAS_CONFIG|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY'
 }


### PR DESCRIPTION
show_env is showing all AWS credentials on the log and it is a security problem.