### PR TITLE
Stop installing deprecated source lists

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -63,9 +63,6 @@ ENV ZULU_OPENJDK_VERSION="8=8.17.0.3"
 ENV LANG="C.UTF-8"
 
 RUN echo "===> Updating debian ....." \
-    # TODO debian jessie has been deprecated and is only ex
-    && echo "deb http://archive.debian.org/debian/ jessie main" > /etc/apt/sources.list \
-    && echo "deb http://security.debian.org jessie/updates main" >> /etc/apt/sources.list \
     && apt-get -qq update \
     \
     && echo "===> Installing curl wget netcat python...." \


### PR DESCRIPTION
I was able to replicate this locally by setting a `local.make` with some "snapshot" settings:

Then 

```
Step 30/32 : RUN echo "===> Updating debian ....."     && echo "deb http://archive.debian.org/debian/ jessie main" > /etc/apt/sources.list     && echo "deb http://security.debian.org jessie/updates main" >> /etc/apt/sources.list     && apt-get -qq update         && echo "===> Installing curl wget netcat python...."     && DEBIAN_FRONTEND=noninteractive apt-get install -y                 apt-transport-https                 curl                 git                 wget                 netcat                 python=${PYTHON_VERSION}     && echo "===> Installing python packages ..."      && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION}     && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20     && apt remove --purge -y git     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}"     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9     && echo "deb http://repos.azulsystems.com/debian stable  main" >> /etc/apt/sources.list.d/zulu.list     && apt-get -qq update     && apt-get -y install zulu-${ZULU_OPENJDK_VERSION}     && echo "===> Installing Kerberos Patch ..."     && DEBIAN_FRONTEND=noninteractive apt-get -y install krb5-user     && rm -rf /var/lib/apt/lists/*     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}/deb/${CONFLUENT_MAJOR_VERSION}.${CONFLUENT_MINOR_VERSION}"     && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -L ${CONFLUENT_PACKAGES_REPO}/deb/${CONFLUENT_MAJOR_VERSION}.${CONFLUENT_MINOR_VERSION}/archive.key | apt-key add - ; fi     && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO}/deb/${CONFLUENT_MAJOR_VERSION}.${CONFLUENT_MINOR_VERSION} stable main" >> /etc/apt/sources.list
 ---> Running in fb2d7ceadee5
===> Updating debian .....
W: GPG error: http://archive.debian.org jessie Release: The following signatures were invalid: KEYEXPIRED 1587841717
===> Installing curl wget netcat python....
```

I then re-ran `make build-debian` and it got past this stage and finished:

```
[Warning] One or more build-args [CONFLUENT_MINOR_VERSION CONFLUENT_PATCH_VERSION CONFLUENT_PLATFORM_LABEL KAFKA_VERSION CONFLUENT_MAJOR_VERSION] were not consumed
Successfully built 079637f82add
Successfully tagged confluentinc/cp-rpm-enterprise-kafka:latest
```

```
aegelhofer@Andrew-Egelhofer's- ce-kafka % docker image ls
REPOSITORY                                      TAG                 IMAGE ID            CREATED             SIZE
confluentinc/cp-rpm-enterprise-kafka            4.0.4-SNAPSHOT      079637f82add        2 minutes ago       1.25GB
confluentinc/cp-rpm-enterprise-kafka            4.0.4-SNAPSHOT-1    079637f82add        2 minutes ago       1.25GB
confluentinc/cp-rpm-enterprise-kafka            c71edfe             079637f82add        2 minutes ago       1.25GB
confluentinc/cp-rpm-enterprise-kafka            latest              079637f82add        2 minutes ago       1.25GB
confluentinc/cp-enterprise-kafka                4.0.4-SNAPSHOT      df502f53af14        3 minutes ago       579MB
confluentinc/cp-enterprise-kafka                4.0.4-SNAPSHOT-1    df502f53af14        3 minutes ago       579MB
confluentinc/cp-enterprise-kafka                c71edfe             df502f53af14        3 minutes ago       579MB
confluentinc/cp-enterprise-kafka                latest              df502f53af14        3 minutes ago       579MB
confluentinc/cp-enterprise-replicator           4.0.4-SNAPSHOT      0cebb67a1c91        3 minutes ago       712MB
confluentinc/cp-enterprise-replicator           4.0.4-SNAPSHOT-1    0cebb67a1c91        3 minutes ago       712MB
confluentinc/cp-enterprise-replicator           c71edfe             0cebb67a1c91        3 minutes ago       712MB
confluentinc/cp-enterprise-replicator           latest              0cebb67a1c91        3 minutes ago       712MB
confluentinc/cp-kafkacat                        4.0.4-SNAPSHOT      1da9ebc360c8        4 minutes ago       122MB
confluentinc/cp-kafkacat                        4.0.4-SNAPSHOT-1    1da9ebc360c8        4 minutes ago       122MB
confluentinc/cp-kafkacat                        c71edfe             1da9ebc360c8        4 minutes ago       122MB
confluentinc/cp-kafkacat                        latest              1da9ebc360c8        4 minutes ago       122MB
<none>                                          <none>              80bf87ea21fe        4 minutes ago       609MB
confluentinc/cp-rpm-enterprise-control-center   4.0.4-SNAPSHOT      6efe9a0fadc0        7 minutes ago       1.1GB
confluentinc/cp-rpm-enterprise-control-center   4.0.4-SNAPSHOT-1    6efe9a0fadc0        7 minutes ago       1.1GB
confluentinc/cp-rpm-enterprise-control-center   c71edfe             6efe9a0fadc0        7 minutes ago       1.1GB
confluentinc/cp-rpm-enterprise-control-center   latest              6efe9a0fadc0        7 minutes ago       1.1GB
confluentinc/cp-enterprise-control-center       4.0.4-SNAPSHOT      6ada3b4caa32        10 minutes ago      601MB
confluentinc/cp-enterprise-control-center       4.0.4-SNAPSHOT-1    6ada3b4caa32        10 minutes ago      601MB
confluentinc/cp-enterprise-control-center       c71edfe             6ada3b4caa32        10 minutes ago      601MB
confluentinc/cp-enterprise-control-center       latest              6ada3b4caa32        10 minutes ago      601MB
confluentinc/cp-kafka-connect                   4.0.4-SNAPSHOT      8ad99da3eeeb        11 minutes ago      840MB
confluentinc/cp-kafka-connect                   4.0.4-SNAPSHOT-1    8ad99da3eeeb        11 minutes ago      840MB
confluentinc/cp-kafka-connect                   c71edfe             8ad99da3eeeb        11 minutes ago      840MB
confluentinc/cp-kafka-connect                   latest              8ad99da3eeeb        11 minutes ago      840MB
confluentinc/cp-kafka-connect-base              4.0.4-SNAPSHOT      8afa4994eb16        12 minutes ago      692MB
confluentinc/cp-kafka-connect-base              4.0.4-SNAPSHOT-1    8afa4994eb16        12 minutes ago      692MB
confluentinc/cp-kafka-connect-base              c71edfe             8afa4994eb16        12 minutes ago      692MB
confluentinc/cp-kafka-connect-base              latest              8afa4994eb16        12 minutes ago      692MB
confluentinc/cp-schema-registry                 4.0.4-SNAPSHOT      5efc45517450        13 minutes ago      636MB
confluentinc/cp-schema-registry                 4.0.4-SNAPSHOT-1    5efc45517450        13 minutes ago      636MB
confluentinc/cp-schema-registry                 c71edfe             5efc45517450        13 minutes ago      636MB
confluentinc/cp-schema-registry                 latest              5efc45517450        13 minutes ago      636MB
confluentinc/cp-kafka-rest                      4.0.4-SNAPSHOT      340bebf6d0be        14 minutes ago      627MB
confluentinc/cp-kafka-rest                      4.0.4-SNAPSHOT-1    340bebf6d0be        14 minutes ago      627MB
confluentinc/cp-kafka-rest                      c71edfe             340bebf6d0be        14 minutes ago      627MB
confluentinc/cp-kafka-rest                      latest              340bebf6d0be        14 minutes ago      627MB
confluentinc/cp-rpm-kafka                       4.0.4-SNAPSHOT      a0b12d69626c        15 minutes ago      1.05GB
confluentinc/cp-rpm-kafka                       4.0.4-SNAPSHOT-1    a0b12d69626c        15 minutes ago      1.05GB
confluentinc/cp-rpm-kafka                       c71edfe             a0b12d69626c        15 minutes ago      1.05GB
confluentinc/cp-rpm-kafka                       latest              a0b12d69626c        15 minutes ago      1.05GB
confluentinc/cp-kafka                           4.0.4-SNAPSHOT      c421e9e46ae3        18 minutes ago      542MB
confluentinc/cp-kafka                           4.0.4-SNAPSHOT-1    c421e9e46ae3        18 minutes ago      542MB
confluentinc/cp-kafka                           c71edfe             c421e9e46ae3        18 minutes ago      542MB
confluentinc/cp-kafka                           latest              c421e9e46ae3        18 minutes ago      542MB
confluentinc/cp-rpm-zookeeper                   4.0.4-SNAPSHOT      a49fa0bf9440        18 minutes ago      1.05GB
confluentinc/cp-rpm-zookeeper                   4.0.4-SNAPSHOT-1    a49fa0bf9440        18 minutes ago      1.05GB
confluentinc/cp-rpm-zookeeper                   c71edfe             a49fa0bf9440        18 minutes ago      1.05GB
confluentinc/cp-rpm-zookeeper                   latest              a49fa0bf9440        18 minutes ago      1.05GB
confluentinc/cp-zookeeper                       4.0.4-SNAPSHOT      1d40971811ea        21 minutes ago      542MB
confluentinc/cp-zookeeper                       4.0.4-SNAPSHOT-1    1d40971811ea        21 minutes ago      542MB
confluentinc/cp-zookeeper                       c71edfe             1d40971811ea        21 minutes ago      542MB
confluentinc/cp-zookeeper                       latest              1d40971811ea        21 minutes ago      542MB
confluentinc/cp-rpm-base                        4.0.4-SNAPSHOT      d5b9b5a2a340        21 minutes ago      764MB
confluentinc/cp-rpm-base                        4.0.4-SNAPSHOT-1    d5b9b5a2a340        21 minutes ago      764MB
confluentinc/cp-rpm-base                        c71edfe             d5b9b5a2a340        21 minutes ago      764MB
confluentinc/cp-rpm-base                        latest              d5b9b5a2a340        21 minutes ago      764MB
confluentinc/cp-base                            4.0.4-SNAPSHOT      8b277a6355ad        25 minutes ago      483MB
confluentinc/cp-base                            4.0.4-SNAPSHOT-1    8b277a6355ad        25 minutes ago      483MB
confluentinc/cp-base                            c71edfe             8b277a6355ad        25 minutes ago      483MB
confluentinc/cp-base                            latest              8b277a6355ad        25 minutes ago      483MB
```