### PR TITLE
ST-3599: Remove show_env function because it exposes secrets

### DIFF
--- a/debian/base/include/etc/confluent/docker/bash-config
+++ b/debian/base/include/etc/confluent/docker/bash-config
@@ -21,8 +21,3 @@ if [ "${TRACE:-}" == "true" ]; then
   set -o verbose \
       -o xtrace
 fi
-
-
-function show_env {
-    env | sort | grep -vP 'PASSWORD|JAAS_CONFIG'
-}

--- a/debian/enterprise-control-center/include/etc/confluent/docker/run
+++ b/debian/enterprise-control-center/include/etc/confluent/docker/run
@@ -22,9 +22,6 @@
 #Ignoring Mesos override errors
 . /etc/confluent/docker/apply-mesos-overrides || true
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/debian/enterprise-replicator-executable/include/etc/confluent/docker/run
+++ b/debian/enterprise-replicator-executable/include/etc/confluent/docker/run
@@ -19,9 +19,6 @@
 . /etc/confluent/docker/mesos-setup.sh
 . /etc/confluent/docker/apply-mesos-overrides
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/debian/kafka-connect-base/include/etc/confluent/docker/run
+++ b/debian/kafka-connect-base/include/etc/confluent/docker/run
@@ -19,9 +19,6 @@
 . /etc/confluent/docker/mesos-setup.sh
 . /etc/confluent/docker/apply-mesos-overrides
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/debian/kafka-mqtt/include/etc/confluent/docker/run
+++ b/debian/kafka-mqtt/include/etc/confluent/docker/run
@@ -16,9 +16,6 @@
 
 . /etc/confluent/docker/bash-config
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/debian/kafka-rest/include/etc/confluent/docker/run
+++ b/debian/kafka-rest/include/etc/confluent/docker/run
@@ -19,9 +19,6 @@
 . /etc/confluent/docker/mesos-setup.sh
 . /etc/confluent/docker/apply-mesos-overrides
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/debian/kafka/include/etc/confluent/docker/run
+++ b/debian/kafka/include/etc/confluent/docker/run
@@ -25,9 +25,6 @@ if [ $# -ne 0 ]; then
   done
 fi
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/debian/schema-registry/include/etc/confluent/docker/run
+++ b/debian/schema-registry/include/etc/confluent/docker/run
@@ -19,9 +19,6 @@
 . /etc/confluent/docker/mesos-setup.sh
 . /etc/confluent/docker/apply-mesos-overrides
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/debian/zookeeper/include/etc/confluent/docker/run
+++ b/debian/zookeeper/include/etc/confluent/docker/run
@@ -16,9 +16,6 @@
 
 . /etc/confluent/docker/bash-config
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 


### PR DESCRIPTION
We don't want to print the environment variables in the logs during startup because they contain sensitive data.