### PR TITLE
ST-3962: update confluent-docker-utils to latest

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -77,7 +77,7 @@ RUN echo "===> Updating debian ....." \
     && echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
-    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
+    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39 \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
     && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \

--- a/debian/base/Dockerfile.rpm
+++ b/debian/base/Dockerfile.rpm
@@ -75,7 +75,7 @@ RUN echo "===> Installing curl wget netcat python...." \
 RUN echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
-    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
+    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39 \
     && yum remove -y git
 
 RUN echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \


### PR DESCRIPTION
### Deprecation Notice

This is used for building images for version 4.1.x or lower, and should not be used for adding new images.

For the 5.4.0 release and greater the images have been migrated to the following repositories:

* [common-docker](https://github.com/confluentinc/common-docker)
* [control-center-images](https://github.com/confluentinc/control-center-images)
* [kafkacat-images](https://github.com/confluentinc/kafkacat-images)
* [kafka-images](https://github.com/confluentinc/kafka-images)
* [kafka-mqtt-images](https://github.com/confluentinc/kafka-mqtt-images)
* [kafka-replicator-images](https://github.com/confluentinc/kafka-replicator-images)
* [kafka-rest-images](https://github.com/confluentinc/kafka-rest-images)
* [kafka-streams-examples](https://github.com/confluentinc/kafka-streams-examples)
* [ksql-images](https://github.com/confluentinc/ksql-images)
* [schema-registry-images](https://github.com/confluentinc/schema-registry-images)
