### PR TITLE
ST-3962: update confluent-docker-utils to latest

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -31,7 +31,7 @@ LABEL io.confluent.docker=true
 
 # Python
 ENV PYTHON_VERSION="2.7.9-1"
-ENV PYTHON_PIP_VERSION="8.1.2"
+ENV PYTHON_PIP_VERSION="20.1.1"
 
 # Confluent
 ENV SCALA_VERSION="2.11"
@@ -76,7 +76,7 @@ RUN echo "===> Updating debian ....." \
     && echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
-    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
+    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39 \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 \

--- a/debian/base/Dockerfile.rpm
+++ b/debian/base/Dockerfile.rpm
@@ -31,7 +31,7 @@ LABEL io.confluent.docker=true
 # # Python
 # # TODO: get this version
 # # ENV PYTHON_VERSION="2.7.9-1"
-ENV PYTHON_PIP_VERSION="9.0.1"
+ENV PYTHON_PIP_VERSION="20.1.1"
 
 # Confluent
 ENV SCALA_VERSION="2.11"
@@ -75,7 +75,7 @@ RUN echo "===> Installing curl wget netcat python...." \
 RUN echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
-    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
+    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39 \
     && yum remove -y git
 
 RUN echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \


### PR DESCRIPTION
Also updates `pip` version to 20.1.1 to make builds pass

Since there's no Jenkinsfile associated that triggers automated test, I verified branches 4.0.x ... 5.3.x to make sure that I can successfully build images by invoking `make build-debian CONFLUENT_PACKAGES_REPO='<staging-repo-for-packages-of-corresponding-version>' PRERELEASE_REVISION=1 PRERELEASE_SUFFIX=SNAPSHOT`. 

There were unrelated intermittent failures during rpm package installations with error messages like `Header V3 RSA/SHA256 Signature, key ID f4a80eb5: BAD`. However, subsequent runs passed successfully. 

This PR should be merged all the way up to 5.3.x. 