### PR TITLE
Pin pyrsistent

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -76,7 +76,7 @@ RUN echo "===> Updating debian ....." \
     && echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
-    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39 \
+    && pip install --no-cache-dir 'pyrsistent<0.17.0' git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39 \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 \

--- a/debian/base/Dockerfile.rpm
+++ b/debian/base/Dockerfile.rpm
@@ -75,7 +75,7 @@ RUN echo "===> Installing curl wget netcat python...." \
 RUN echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
-    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39 \
+    && pip install --no-cache-dir 'pyrsistent<0.17.0' git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39 \
     && yum remove -y git
 
 RUN echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \


### PR DESCRIPTION
5.2.x failed to build with what looks like `pyrsistent` dropping Py27 Syntax support.

https://jenkins.confluent.io/job/confluentinc/job/cp-docker-images-overlay/job/5.2.x/247/consoleFull

```
13:52:34  [INFO] ===> Configuring ...
13:52:34  [INFO] [91mTraceback (most recent call last):
13:52:34  [INFO]   File "/usr/local/bin/dub", line 11, in <module>
13:52:34  [INFO]     load_entry_point('confluent-docker-utils==0.0.39', 'console_scripts', 'dub')()
13:52:34  [INFO]   File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 489, in load_entry_point
13:52:34  [INFO]     return get_distribution(dist).load_entry_point(group, name)
13:52:34  [INFO]   File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
13:52:34  [INFO] [0m
13:52:34  [INFO] [91m    return ep.load()
13:52:34  [INFO]   File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2443, in load
13:52:34  [INFO] [0m
13:52:34  [INFO] [91m    return self.resolve()
13:52:34  [INFO]   File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2449, in resolve
13:52:34  [INFO] [0m
13:52:34  [INFO] [91m    module = __import__(self.module_name, fromlist=['__name__'], level=0)
13:52:34  [INFO]   File "/usr/local/lib/python2.7/dist-packages/confluent/docker_utils/__init__.py", line 7, in <module>
13:52:34  [INFO]     from compose.config.config import ConfigDetails, ConfigFile, load
13:52:34  [INFO]   File "/usr/local/lib/python2.7/dist-packages/compose/config/__init__.py", line 6, in <module>
13:52:34  [INFO]     from .config import ConfigurationError
13:52:34  [INFO]   File "/usr/local/lib/python2.7/dist-packages/compose/config/config.py", line 51, in <module>
13:52:34  [INFO]     from .validation import match_named_volumes
13:52:34  [INFO]   File "/usr/local/lib/python2.7/dist-packages/compose/config/validation.py", line 12, in <module>
13:52:34  [INFO] [0m
13:52:34  [INFO] [91m    from jsonschema import Draft4Validator
13:52:34  [INFO]   File "/usr/local/lib/python2.7/dist-packages/jsonschema/__init__.py", line 21, in <module>
13:52:34  [INFO]     from jsonschema._types import TypeChecker
13:52:34  [INFO]   File "/usr/local/lib/python2.7/dist-packages/jsonschema/_types.py", line 3, in <module>
13:52:34  [INFO]     from pyrsistent import pmap
13:52:34  [INFO]   File "/usr/local/lib/python2.7/dist-packages/pyrsistent/__init__.py", line 3, in <module>
13:52:34  [INFO]     from pyrsistent._pmap import pmap, m, PMap
13:52:34  [INFO] [0m
13:52:34  [INFO] [91m  File "/usr/local/lib/python2.7/dist-packages/pyrsistent/_pmap.py", line 98
13:52:34  [INFO]     ) from e
13:52:34  [INFO]          ^
13:52:34  [INFO] SyntaxError: [0m
13:52:34  [INFO] [91minvalid syntax
13:52:34  [INFO] [0m
```


Checking working/broken logs, and the latest releases for this project, yes, they dropped Py27 Syntax: https://github.com/tobgu/pyrsistent/compare/v0.16.0...v0.17.0

```
0.17.0, 2020-09-08
 * Remove Python 2 support code. This includes dropping some compatibility code and the dependency on
   six. Thanks @djailla for this.
```

Others also seem to be running into this issue, as the `pyrsistent` maintainers didn't set a `python_requires` in their setup.py config: https://github.com/tobgu/pyrsistent/issues/205

So maybe they'll fix it on their end if they yank and re-issue version 0.17.0 and let pip figure things out.