### PR TITLE
use `--no-install-recommends` in `apt-get` in dockerfiles to save space

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -69,7 +69,7 @@ RUN echo "===> Updating debian ....." \
     && apt-get -qq update \
     \
     && echo "===> Installing curl wget netcat python...." \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
                 apt-transport-https \
                 curl \
                 gnupg-curl \
@@ -86,9 +86,9 @@ RUN echo "===> Updating debian ....." \
     && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \
     && echo "deb http://repos.azulsystems.com/debian stable  main" >> /etc/apt/sources.list.d/zulu.list \
     && apt-get -qq update \
-    && apt-get -y install zulu-${ZULU_OPENJDK_VERSION} \
+    && apt-get --no-install-recommends install -y zulu-${ZULU_OPENJDK_VERSION} \
     && echo "===> Installing Kerberos Patch ..." \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y install krb5-user \
+    && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y krb5-user \
     && rm -rf /var/lib/apt/lists/* \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}/deb/${CONFLUENT_MAJOR_VERSION}.${CONFLUENT_MINOR_VERSION}" \
     && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -L ${CONFLUENT_PACKAGES_REPO}/deb/${CONFLUENT_MAJOR_VERSION}.${CONFLUENT_MINOR_VERSION}/archive.key | apt-key add - ; fi \

--- a/debian/enterprise-control-center/Dockerfile
+++ b/debian/enterprise-control-center/Dockerfile
@@ -33,7 +33,7 @@ ENV CONTROL_CENTER_CONFIG_DIR=/etc/confluent-${COMPONENT}
 EXPOSE 9021
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && apt-get update && apt-get install -y confluent-${COMPONENT}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get update && apt-get --no-install-recommends install -y confluent-${COMPONENT}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     \
     && echo "===> Cleaning up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \

--- a/debian/enterprise-kafka/Dockerfile
+++ b/debian/enterprise-kafka/Dockerfile
@@ -29,7 +29,7 @@ ENV COMPONENT=kafka
 EXPOSE 9092
 
 RUN echo "===> installing confluent-rebalancer ..." \
-    && apt-get update && apt-get install -y \
+    && apt-get update && apt-get --no-install-recommends install -y \
           confluent-rebalancer=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     \
     && echo "===> clean up ..."  \

--- a/debian/enterprise-replicator/Dockerfile
+++ b/debian/enterprise-replicator/Dockerfile
@@ -26,7 +26,7 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 
 RUN echo "===> Installing Replicator ..." \
     && apt-get -qq update \
-     && apt-get install -y \
+     && apt-get --no-install-recommends install -y \
         confluent-kafka-connect-replicator=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
      && echo "===> Cleaning up ..."  \
      && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*

--- a/debian/kafka-connect-base/Dockerfile
+++ b/debian/kafka-connect-base/Dockerfile
@@ -31,12 +31,12 @@ EXPOSE 8083
 
 RUN echo "===> Installing Schema Registry (for Avro jars) ..." \
     && apt-get -qq update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends install -y \
         confluent-schema-registry=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..."\
-    && apt-get install -y confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get --no-install-recommends install -y confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Installing Confluent Hub client ..."\
-    && apt-get install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get --no-install-recommends install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     echo "===> Setting up ${COMPONENT} dirs ..." \

--- a/debian/kafka-connect/Dockerfile
+++ b/debian/kafka-connect/Dockerfile
@@ -28,7 +28,7 @@ ENV COMPONENT=kafka-connect
 
 RUN echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
     && apt-get -qq update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends install -y \
         confluent-kafka-connect-jdbc=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
         confluent-kafka-connect-elasticsearch=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
         confluent-kafka-connect-storage-common=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \

--- a/debian/kafka-mqtt/Dockerfile
+++ b/debian/kafka-mqtt/Dockerfile
@@ -29,7 +29,7 @@ ENV COMPONENT=kafka-mqtt
 EXPOSE 1883
 
 RUN echo "===> installing ${COMPONENT}..." \
-    && apt-get update && apt-get install -y \
+    && apt-get update && apt-get --no-install-recommends install -y \
         confluent-${COMPONENT}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> clean up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \

--- a/debian/kafka-rest/Dockerfile
+++ b/debian/kafka-rest/Dockerfile
@@ -29,7 +29,7 @@ ENV COMPONENT=kafka-rest
 EXPOSE 8082
 
 RUN echo "===> installing ${COMPONENT}..." \
-    && apt-get update && apt-get install -y \
+    && apt-get update && apt-get --no-install-recommends install -y \
         confluent-${COMPONENT}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
         confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
         confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \

--- a/debian/kafka/Dockerfile
+++ b/debian/kafka/Dockerfile
@@ -35,7 +35,7 @@ ENV COMPONENT=kafka
 EXPOSE 9092
 
 RUN echo "===> installing ${COMPONENT}..." \
-    && apt-get update && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get update && apt-get --no-install-recommends install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     \
     && echo "===> clean up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \

--- a/debian/kafkacat/Dockerfile
+++ b/debian/kafkacat/Dockerfile
@@ -8,7 +8,7 @@ ENV BUILD_PACKAGES="build-essential cmake python git curl zlib1g-dev libsasl2-de
 
 RUN echo "Building kafkacat ....." \
     && apt-get update -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y $BUILD_PACKAGES \
+    && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y $BUILD_PACKAGES \
     && git clone https://github.com/edenhill/kafkacat \
     && cd kafkacat \
     && git checkout tags/debian/$VERSION \
@@ -29,7 +29,7 @@ COPY --from=0 /build/kafkacat/kafkacat /usr/local/bin/
 
 RUN apt-get update -y \
     && echo "Installing runtime dependencies for SSL and SASL support ...." \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
         openssl \
         libssl1.1 \
         libsasl2-2 \

--- a/debian/schema-registry/Dockerfile
+++ b/debian/schema-registry/Dockerfile
@@ -31,7 +31,7 @@ ENV COMPONENT=schema-registry
 EXPOSE 8081
 
 RUN echo "===> installing ${COMPONENT}..." \
-    && apt-get update && apt-get install -y \
+    && apt-get update && apt-get --no-install-recommends install -y \
         confluent-${COMPONENT}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
         confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
         confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \

--- a/debian/server-connect-base/Dockerfile
+++ b/debian/server-connect-base/Dockerfile
@@ -31,14 +31,14 @@ EXPOSE 8083
 
 RUN echo "===> Installing Schema Registry (for Avro jars) ..." \
     && apt-get -qq update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends install -y \
         confluent-schema-registry=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..."\
-    && apt-get install -y confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get --no-install-recommends install -y confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Installing Confluent security plugins ..."\
-    && apt-get install -y confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get --no-install-recommends install -y confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Installing Confluent Hub client ..."\
-    && apt-get install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get --no-install-recommends install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     echo "===> Setting up ${COMPONENT} dirs ..." \

--- a/debian/server-connect/Dockerfile
+++ b/debian/server-connect/Dockerfile
@@ -28,7 +28,7 @@ ENV COMPONENT=kafka-connect
 
 RUN echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
     && apt-get -qq update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends install -y \
         confluent-kafka-connect-jdbc=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
         confluent-kafka-connect-elasticsearch=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
         confluent-kafka-connect-storage-common=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \

--- a/debian/server/Dockerfile
+++ b/debian/server/Dockerfile
@@ -35,9 +35,9 @@ ENV COMPONENT=kafka
 EXPOSE 9092
 
 RUN echo "===> installing ${COMPONENT}..." \
-    && apt-get update && apt-get install -y confluent-server=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get update && apt-get --no-install-recommends install -y confluent-server=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> installing confluent-rebalancer ..." \
-    && apt-get update && apt-get install -y \
+    && apt-get update && apt-get --no-install-recommends install -y \
               confluent-rebalancer=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     \
     && echo "===> clean up ..."  \

--- a/debian/zookeeper/Dockerfile
+++ b/debian/zookeeper/Dockerfile
@@ -28,7 +28,7 @@ LABEL io.confluent.docker=true
 ENV COMPONENT=zookeeper
 
 RUN echo "===> installing ${COMPONENT}..." \
-    && apt-get update && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get update && apt-get --no-install-recommends install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     \
     && echo "===> clean up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>