### PR TITLE
fix: Pin bootstrap.pypa to a Python2.7 Script

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -74,7 +74,7 @@ RUN echo "===> Updating debian ....." \
                 netcat \
                 python=${PYTHON_VERSION} \
     && echo "===> Installing python packages ..."  \
-    && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
+    && curl -fSL "https://bootstrap.pypa.io/2.7/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
     && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.40 \
     && apt remove --purge -y git \

--- a/debian/base/Dockerfile.rpm
+++ b/debian/base/Dockerfile.rpm
@@ -73,7 +73,7 @@ RUN echo "===> Installing curl wget netcat python...." \
                 python
 
 RUN echo "===> Installing python packages ..."  \
-    && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
+    && curl -fSL "https://bootstrap.pypa.io/2.7/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
     && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.40 \
     && yum remove -y git


### PR DESCRIPTION
Theres no effective way to test this in CI/CD, so I'll just do it by hand in a `debian:jessie` container:

## Testing

Check for regression
```
root@5bf63de6a936:/# curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1883k  100 1883k    0     0  2152k      0 --:--:-- --:--:-- --:--:-- 2152k
Traceback (most recent call last):
  File "<stdin>", line 24226, in <module>
  File "<stdin>", line 199, in main
  File "<stdin>", line 82, in bootstrap
  File "/tmp/tmpl8JEuQ/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
```

Check the fix:

```
root@5bf63de6a936:/# curl -fSL "https://bootstrap.pypa.io/2.7/get-pip.py" | python
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1863k  100 1863k    0     0  2381k      0 --:--:-- --:--:-- --:--:-- 2380k
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
Collecting pip<21.0
  Downloading pip-20.3.4-py2.py3-none-any.whl (1.5 MB)
     |################################| 1.5 MB 1.8 MB/s
Collecting setuptools<45
  Downloading setuptools-44.1.1-py2.py3-none-any.whl (583 kB)
     |################################| 583 kB 2.5 MB/s
Collecting wheel
  Downloading wheel-0.36.2-py2.py3-none-any.whl (35 kB)
Installing collected packages: pip, setuptools, wheel
Successfully installed pip-20.3.4 setuptools-44.1.1 wheel-0.36.2
root@5bf63de6a936:/# pip install --no-cache-dir --upgrade pip==20.1.1
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
Collecting pip==20.1.1
  Downloading pip-20.1.1-py2.py3-none-any.whl (1.5 MB)
     |################################| 1.5 MB 1.8 MB/s
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 20.3.4
    Uninstalling pip-20.3.4:
      Successfully uninstalled pip-20.3.4
Successfully installed pip-20.1.1
```

Looks good to me.