### PR TITLE
MINOR: Update version of docker-utils to v0.0.40-python2 and pip to latest py27 supported version

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -31,7 +31,7 @@ LABEL io.confluent.docker=true
 
 # Python
 ENV PYTHON_VERSION="2.7.9-1"
-ENV PYTHON_PIP_VERSION="20.1.1"
+ENV PYTHON_PIP_VERSION="20.3.4"
 
 # Confluent
 ENV SCALA_VERSION="2.11"
@@ -76,7 +76,7 @@ RUN echo "===> Updating debian ....." \
     && echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/pip/2.7/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
-    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.40 \
+    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.40-python2 \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 \


### PR DESCRIPTION
confluent-docker-utils tag `v0.0.40-python2` update evicts some needless dependencies for runtime, and updates a couple of python modules to their latest python2 supported version.

### Deprecation Notice

This is used for building images for version 4.1.x or lower, and should not be used for adding new images.

For the 5.4.0 release and greater the images have been migrated to the following repositories:

* [common-docker](https://github.com/confluentinc/common-docker)
* [control-center-images](https://github.com/confluentinc/control-center-images)
* [kafkacat-images](https://github.com/confluentinc/kafkacat-images)
* [kafka-images](https://github.com/confluentinc/kafka-images)
* [kafka-mqtt-images](https://github.com/confluentinc/kafka-mqtt-images)
* [kafka-replicator-images](https://github.com/confluentinc/kafka-replicator-images)
* [kafka-rest-images](https://github.com/confluentinc/kafka-rest-images)
* [kafka-streams-examples](https://github.com/confluentinc/kafka-streams-examples)
* [ksql-images](https://github.com/confluentinc/ksql-images)
* [schema-registry-images](https://github.com/confluentinc/schema-registry-images)
