### PR TITLE
[skip secret scan] build: Remove expired ca-cert

### DIFF
--- a/debian/base/Dockerfile
+++ b/debian/base/Dockerfile
@@ -80,6 +80,8 @@ RUN echo "===> Updating debian ....." \
     && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.42-python2 \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
+    && rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
+    && update-ca-certificates \
     && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \
     && curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-2_all.deb \
     && dpkg --install zulu-repo_1.0.0-2_all.deb \


### PR DESCRIPTION
It seems this cert has expired, and is getting in the way of importing GPG Keys:

```
root@4c33dd1858d0:/# openssl x509 -in /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt -noout -text
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            44:af:b0:80:d6:a3:27:ba:89:30:39:86:2e:f8:40:6b
    Signature Algorithm: sha1WithRSAEncryption
        Issuer: O=Digital Signature Trust Co., CN=DST Root CA X3
        Validity
            Not Before: Sep 30 21:12:19 2000 GMT
            Not After : Sep 30 14:01:15 2021 GMT
```

This is a similar fix done in https://github.com/confluentinc/confluent-docker-build-images/pull/164