### PR TITLE
build: Remove show_env calls

### DIFF
--- a/debian/server-connect-base/include/etc/confluent/docker/run
+++ b/debian/server-connect-base/include/etc/confluent/docker/run
@@ -19,9 +19,6 @@
 . /etc/confluent/docker/mesos-setup.sh
 . /etc/confluent/docker/apply-mesos-overrides
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/debian/server/include/etc/confluent/docker/run
+++ b/debian/server/include/etc/confluent/docker/run
@@ -25,9 +25,6 @@ if [ $# -ne 0 ]; then
   done
 fi
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 


### PR DESCRIPTION
Followup to https://github.com/confluentinc/cp-docker-images/pull/855